### PR TITLE
[feat] 스프링 시큐리티 기본 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -41,8 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // security
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
-    //implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
 

--- a/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
@@ -1,0 +1,77 @@
+package com.tave.tavewebsite.global.security.config;
+
+import com.tave.tavewebsite.domain.member.entity.RoleType;
+import com.tave.tavewebsite.global.security.filter.CsrfTokenResponseHeaderBindingFilter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class Config {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+        corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+        corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"));
+        corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type", "X-XSRF-TOKEN"));
+        corsConfiguration.setExposedHeaders(List.of("X-XSRF-TOKEN"));
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(
+                corsConfigurationSource()));
+
+        http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.csrfTokenRepository(
+                        CookieCsrfTokenRepository.withHttpOnlyFalse())
+                .and()
+                .addFilterAfter(new CsrfTokenResponseHeaderBindingFilter(), CsrfFilter.class)
+        );
+
+        http.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                authorizationManagerRequestMatcherRegistry
+                        // 비회원 전용 api
+                        .requestMatchers("/test", "post").permitAll()
+                        // 일반 회원 전용 api
+                        .requestMatchers("/member").hasRole(RoleType.MEMBER.name())
+                        // 미허가 운영진 전용 api
+                        .requestMatchers("/un/manager").hasRole(RoleType.UNAUTHORIZED_MANAGER.name())
+                        // 운영진 전용 api
+                        .requestMatchers("/manager").hasRole(RoleType.MANAGER.name())
+                        // 회장 전용 api
+                        .requestMatchers("/admin").hasRole(RoleType.ADMIN.name())
+                        .anyRequest().authenticated()
+        );
+
+        http.formLogin().disable();
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/global/security/filter/CsrfTokenResponseHeaderBindingFilter.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/filter/CsrfTokenResponseHeaderBindingFilter.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class CsrfTokenResponseHeaderBindingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+
+        if (csrfToken != null) {
+            response.setHeader("X-XSRF-TOKEN", csrfToken.getToken());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #28 
> Close #28 

## 📑 작업 내용
> - CORS는 모두 허용으로 설정했습니다.
> - CSRF 토큰을 추출하여 헤더에 포함하여 반환했습니다.
CSRF 토큰이 없다면 POST, UPDATE 등 데이터베이스에 접근하는 요청이 거부 당합니다.
따라서 POST, UPDATE 같은 요청을 한다면 반드시 헤더에 CSRF 토큰을 추가하여 보내야 합니다.

![image](https://github.com/user-attachments/assets/d795a24b-3e24-4082-a8f1-644bce5a478e)
위의 이미지를 보시면, 헤더에 X-XSRF-TOKEN에 토큰 값이 담겨져 있는 것을 확인할 수 있습니다.

토큰 값은 어떠한 요청이든 서버로 접근하는 모든 요청의 반환값 헤더에 포함되어 있습니다.

이후 저 토큰 값을 헤더에 포함시켜 프론트에서 다시 요청하면
![image](https://github.com/user-attachments/assets/5c5185a2-ab6a-4162-a0a4-4ed78406ab22)
위 사진과 같이 POST 요청에 성공할 수 있습니다.
