### PR TITLE
[Feat] 동아리 이력 crud 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
@@ -1,0 +1,50 @@
+package com.tave.tavewebsite.domain.history.controller;
+
+import com.tave.tavewebsite.domain.history.dto.request.HistoryRequestDto;
+import com.tave.tavewebsite.domain.history.dto.response.HistoryResponseDto;
+import com.tave.tavewebsite.domain.history.service.HistoryService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/manager/history")
+@RequiredArgsConstructor
+public class ManagerHistoryController {
+
+    private final HistoryService historyService;
+
+    @GetMapping
+    public SuccessResponse<List<HistoryResponseDto>> getAllHistory() {
+        List<HistoryResponseDto> allOrderByGenerationDesc = historyService.findAllOrderByGenerationDesc();
+        return new SuccessResponse<>(allOrderByGenerationDesc);
+    }
+
+    @PostMapping
+    public SuccessResponse postHistory(@RequestBody @Valid HistoryRequestDto historyRequestDto) {
+        historyService.save(historyRequestDto);
+        return SuccessResponse.ok();
+    }
+
+    @PatchMapping("/{historyId}")
+    public SuccessResponse updateHistory(@PathVariable("historyId") Long id,
+                                         @RequestBody @Valid HistoryRequestDto historyRequestDto) {
+        historyService.put(id, historyRequestDto);
+        return SuccessResponse.ok();
+    }
+
+    @DeleteMapping("/{historyId}")
+    public SuccessResponse deleteHistory(@PathVariable("historyId") Long id) {
+        historyService.delete(id);
+        return SuccessResponse.ok();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
@@ -38,7 +38,7 @@ public class ManagerHistoryController {
     @PatchMapping("/{historyId}")
     public SuccessResponse updateHistory(@PathVariable("historyId") Long id,
                                          @RequestBody @Valid HistoryRequestDto historyRequestDto) {
-        historyService.put(id, historyRequestDto);
+        historyService.patch(id, historyRequestDto);
         return SuccessResponse.ok();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/history/controller/NormalHistoryController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/controller/NormalHistoryController.java
@@ -1,0 +1,24 @@
+package com.tave.tavewebsite.domain.history.controller;
+
+import com.tave.tavewebsite.domain.history.dto.response.HistoryResponseDto;
+import com.tave.tavewebsite.domain.history.service.HistoryService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/normal/history")
+public class NormalHistoryController {
+
+    private final HistoryService historyService;
+
+    @GetMapping
+    public SuccessResponse<List<HistoryResponseDto>> getPublicHistory() {
+        List<HistoryResponseDto> publicOrderByGenerationDesc = historyService.findPublicOrderByGenerationDesc();
+        return new SuccessResponse<>(publicOrderByGenerationDesc);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/dto/request/HistoryRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/dto/request/HistoryRequestDto.java
@@ -1,0 +1,22 @@
+package com.tave.tavewebsite.domain.history.dto.request;
+
+import com.tave.tavewebsite.domain.history.entity.History;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record HistoryRequestDto(
+        @NotNull(message = "필수로 입력하셔야합니다.") @Size(min = 1, max = 5, message = "1~5 글자 사이로 입력해주세요.")
+        String generation,
+        @NotNull(message = "필수로 입력하셔야합니다.") @Size(min = 1, max = 500, message = "최대 500 글자까지 입력 가능합니다.")
+        String description,
+        @NotNull(message = "필수로 입력하셔야합니다.")
+        Boolean isPublic
+) {
+    public History toHistory() {
+        return History.builder()
+                .generation(this.generation)
+                .description(this.description)
+                .isPublic(this.isPublic)
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/dto/response/HistoryResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/dto/response/HistoryResponseDto.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.history.dto.response;
+
+import com.tave.tavewebsite.domain.history.entity.History;
+
+public record HistoryResponseDto(
+        Long id,
+        String generation,
+        String description,
+        Boolean isPublic
+) {
+    public static HistoryResponseDto of(History history) {
+        return new HistoryResponseDto(history.getId(), history.getGeneration(), history.getDescription(),
+                history.isPublic());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
@@ -48,7 +48,7 @@ public class History extends BaseEntity {
         this.isPublic = isPublic;
     }
 
-    public void putHistory(HistoryRequestDto historyResponseDto) {
+    public void patchHistory(HistoryRequestDto historyResponseDto) {
         generation = historyResponseDto.generation();
         description = historyResponseDto.description();
         isPublic = historyResponseDto.isPublic();

--- a/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
@@ -1,7 +1,13 @@
 package com.tave.tavewebsite.domain.history.entity;
 
+import com.tave.tavewebsite.domain.history.dto.request.HistoryRequestDto;
 import com.tave.tavewebsite.global.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -40,5 +46,11 @@ public class History extends BaseEntity {
         this.generation = generation;
         this.description = description;
         this.isPublic = isPublic;
+    }
+
+    public void putHistory(HistoryRequestDto historyResponseDto) {
+        generation = historyResponseDto.generation();
+        description = historyResponseDto.description();
+        isPublic = historyResponseDto.isPublic();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/history/exception/HistoryErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/exception/HistoryErrorException.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.history.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+public abstract class HistoryErrorException {
+
+    public static class HistoryNotFoundException extends BaseErrorException {
+        public HistoryNotFoundException() {
+            super(HistoryErrorMessage.NOT_FOUND_HISTORY.getCode(), HistoryErrorMessage.NOT_FOUND_HISTORY.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/exception/HistoryErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/exception/HistoryErrorMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.history.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum HistoryErrorMessage {
+
+    NOT_FOUND_HISTORY(400, "History를 찾을 수 없습니다.");
+
+    final int code;
+    final String message;
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/repository/HistoryRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/repository/HistoryRepository.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.history.repository;
+
+import com.tave.tavewebsite.domain.history.entity.History;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface HistoryRepository extends JpaRepository<History, Long> {
+    List<History> findByIsPublicOrderByGenerationDesc(Boolean isPublic);
+
+    List<History> findAllByOrderByGenerationDesc();
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/service/HistoryService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/service/HistoryService.java
@@ -1,0 +1,54 @@
+package com.tave.tavewebsite.domain.history.service;
+
+import com.tave.tavewebsite.domain.history.dto.request.HistoryRequestDto;
+import com.tave.tavewebsite.domain.history.dto.response.HistoryResponseDto;
+import com.tave.tavewebsite.domain.history.entity.History;
+import com.tave.tavewebsite.domain.history.exception.HistoryErrorException.HistoryNotFoundException;
+import com.tave.tavewebsite.domain.history.repository.HistoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+
+    private final HistoryRepository historyRepository;
+
+    @Transactional(readOnly = true)
+    public List<HistoryResponseDto> findPublicOrderByGenerationDesc() {
+        List<History> isPublicOrderByGenerationDesc = historyRepository.findByIsPublicOrderByGenerationDesc(true);
+        List<HistoryResponseDto> historyResponseDtos = new ArrayList<>();
+        for (History history : isPublicOrderByGenerationDesc) {
+            historyResponseDtos.add(HistoryResponseDto.of(history));
+        }
+        return historyResponseDtos;
+    }
+
+    @Transactional(readOnly = true)
+    public List<HistoryResponseDto> findAllOrderByGenerationDesc() {
+        List<History> orderByGenerationDesc = historyRepository.findAllByOrderByGenerationDesc();
+        List<HistoryResponseDto> historyResponseDtos = new ArrayList<>();
+        for (History history : orderByGenerationDesc) {
+            historyResponseDtos.add(HistoryResponseDto.of(history));
+        }
+        return historyResponseDtos;
+    }
+
+    public void save(HistoryRequestDto dto) {
+        historyRepository.save(dto.toHistory());
+    }
+
+    @Transactional
+    public void put(Long id, HistoryRequestDto dto) {
+        History history = historyRepository.findById(id).orElseThrow(HistoryNotFoundException::new);
+        history.putHistory(dto);
+    }
+
+    public void delete(Long id) {
+        historyRepository.findById(id).orElseThrow(HistoryNotFoundException::new);
+        historyRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/history/service/HistoryService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/service/HistoryService.java
@@ -42,13 +42,17 @@ public class HistoryService {
     }
 
     @Transactional
-    public void put(Long id, HistoryRequestDto dto) {
-        History history = historyRepository.findById(id).orElseThrow(HistoryNotFoundException::new);
-        history.putHistory(dto);
+    public void patch(Long id, HistoryRequestDto dto) {
+        History history = validate(id);
+        history.patchHistory(dto);
     }
 
     public void delete(Long id) {
-        historyRepository.findById(id).orElseThrow(HistoryNotFoundException::new);
+        validate(id);
         historyRepository.deleteById(id);
+    }
+
+    private History validate(Long id) {
+        return historyRepository.findById(id).orElseThrow(HistoryNotFoundException::new);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
@@ -75,8 +75,7 @@ public class Config {
 
                         // 운영진 전용 api
                         .requestMatchers("/v1/manager/**")
-                        .hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name(),
-                                RoleType.UNAUTHORIZED_MANAGER.name())
+                        .hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name())
 
                         // 회장 전용 api
                         .requestMatchers("/v1/admin/**").hasRole(RoleType.ADMIN.name())

--- a/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
@@ -75,7 +75,8 @@ public class Config {
 
                         // 운영진 전용 api
                         .requestMatchers("/v1/manager/**")
-                        .hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name())
+                        .hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name(),
+                                RoleType.UNAUTHORIZED_MANAGER.name())
 
                         // 회장 전용 api
                         .requestMatchers("/v1/admin/**").hasRole(RoleType.ADMIN.name())

--- a/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
@@ -3,23 +3,20 @@ package com.tave.tavewebsite.global.security.config;
 import com.tave.tavewebsite.domain.member.entity.RoleType;
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import com.tave.tavewebsite.global.security.exception.CustomAuthenticationEntryPoint;
-import com.tave.tavewebsite.global.security.filter.CsrfTokenResponseHeaderBindingFilter;
 import com.tave.tavewebsite.global.security.filter.JwtAuthenticationFilter;
 import com.tave.tavewebsite.global.security.utils.JwtTokenProvider;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -55,11 +52,7 @@ public class Config {
         http.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(
                 corsConfigurationSource()));
 
-        http.csrf(httpSecurityCsrfConfigurer -> httpSecurityCsrfConfigurer.csrfTokenRepository(
-                        CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .and()
-                .addFilterAfter(new CsrfTokenResponseHeaderBindingFilter(), CsrfFilter.class)
-        );
+        http.csrf(AbstractHttpConfigurer::disable);
 
         http.sessionManagement((session) -> session
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
@@ -67,24 +60,25 @@ public class Config {
         http.authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                 authorizationManagerRequestMatcherRegistry
                         // 비회원 전용 api
-                        .requestMatchers(HttpMethod.POST, "/api/v1/manager").permitAll()
-                        .requestMatchers("/api/v1/manager/test", "/api/v1/manager/signIn", "/api/v1/manager/refresh")
+                        .requestMatchers("/v1/normal/**", "/v1/auth/signup", "/v1/auth/signin", "/v1/auth/refresh")
                         .permitAll()
+
                         // 일반 회원 전용 api
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/manager")
+                        .requestMatchers("/v1/member/**", "/v1/auth/signout", "/v1/auth/delete/**")
                         .hasAnyRole(RoleType.MEMBER.name(), RoleType.UNAUTHORIZED_MANAGER.name(),
                                 RoleType.MANAGER.name(), RoleType.ADMIN.name())
-                        .requestMatchers("/api/v1/manager/signOut")
-                        .hasAnyRole(RoleType.MEMBER.name(), RoleType.UNAUTHORIZED_MANAGER.name(),
-                                RoleType.MANAGER.name(), RoleType.ADMIN.name())
+
                         // 미허가 운영진 전용 api
-                        .requestMatchers("/un/man")
+                        .requestMatchers("/v1/xxxxxxxxx")
                         .hasAnyRole(RoleType.UNAUTHORIZED_MANAGER.name(), RoleType.MANAGER.name(),
                                 RoleType.ADMIN.name())
+
                         // 운영진 전용 api
-                        .requestMatchers("/manager").hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name())
+                        .requestMatchers("/v1/manager/**")
+                        .hasAnyRole(RoleType.MANAGER.name(), RoleType.ADMIN.name())
+
                         // 회장 전용 api
-                        .requestMatchers("/admin").hasRole(RoleType.ADMIN.name())
+                        .requestMatchers("/v1/admin/**").hasRole(RoleType.ADMIN.name())
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -35,6 +35,9 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             setResponse(response, EXPIRED_JWT_TOKEN.getErrorCode(), EXPIRED_JWT_TOKEN.getMessage());
         } else if (request.getAttribute("unsupportedJwtToken") != null) {
             setResponse(response, UNSUPPORTED_JWT_TOKEN.getErrorCode(), UNSUPPORTED_JWT_TOKEN.getMessage());
+        } else {
+            // 나머지 잘못된 요청에 대한 기본 예외 처리
+            setResponse(response, 401, "잘못된 인증 요청입니다."); // 기본적으로 400 상태 코드와 에러 메시지 반환
         }
 
 

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -12,12 +12,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
@@ -37,7 +35,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             setResponse(response, UNSUPPORTED_JWT_TOKEN.getErrorCode(), UNSUPPORTED_JWT_TOKEN.getMessage());
         } else {
             // 나머지 잘못된 요청에 대한 기본 예외 처리
-            setResponse(response, 401, "잘못된 인증 요청입니다."); // 기본적으로 400 상태 코드와 에러 메시지 반환
+            setResponse(response, 401, "잘못된 인증 요청입니다."); // 기본적으로 401 상태 코드와 에러 메시지 반환
         }
 
 

--- a/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
@@ -45,10 +45,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String requestURI = request.getRequestURI();
         // 해당 토큰 검증 필터가 적용되지 않게 하려는 api 경로
-        return requestURI.startsWith("/api/v1/manager/signIn")
-                || requestURI.startsWith("/api/v1/manager/test")
-                || requestURI.startsWith("/api/v1/manager/refresh")
-                || (requestURI.startsWith("/api/v1/manager") && request.getMethod().equals("POST"));
+        return requestURI.startsWith("/v1/normal")
+                || requestURI.startsWith("/v1/auth/signup")
+                || requestURI.startsWith("/v1/auth/signin")
+                || (requestURI.startsWith("/v1/auth/refresh"));
+
     }
 
     // Request Header에서 토큰 정보 추출


### PR DESCRIPTION
## ➕ 연관된 이슈
> #33 
> Close #33 

## 📑 작업 내용
> - jwt 토큰중 refresh 토큰만 쿠키에 저장하고 access 토큰은 private 변수로 로컬 스토리지에 저장해서 사용한다면 csrf 토큰은 사용할 이유가 없다. 탈취한 refresh 토큰만으로는 access토큰을 재발급 받을 수 없기 때문이다. 따라서 csrf 토큰을 비활성화 해주었다.
> - 동아리 이력 중 일반회원이 조회하는 엔드포인트의 경우, NormalHistoryController에 정의해줬다.
> - 동아리 이력 중 운영진이 조회하는 엔드포인트의 경우, ManagerHistoryController에 정의해줬다.
