### PR TITLE
[Feat] 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+
 
     // spring
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -1,0 +1,52 @@
+package com.tave.tavewebsite.domain.member.controller;
+
+import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
+import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.member.service.MemberService;
+import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
+import com.tave.tavewebsite.global.security.entity.JwtToken;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1")
+public class AuthController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/auth/signup")
+    public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
+        MailResponseDto response = memberService.saveMember(requestDto);
+        return new SuccessResponse<>(response);
+    }
+
+    @PostMapping("/auth/signin")
+    public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto) {
+        SignInResponseDto signInResponseDto = memberService.signIn(requestDto);
+        return new SuccessResponse<>(signInResponseDto);
+    }
+
+    @PostMapping("/auth/refresh")
+    public SuccessResponse<JwtToken> refreshToken(@RequestBody RefreshTokenRequestDto requestDto) {
+        JwtToken jwtToken = memberService.refreshToken(requestDto);
+        return new SuccessResponse<>(jwtToken);
+    }
+
+    @GetMapping("/auth/signout")
+    public SuccessResponse signOut(@RequestHeader("Authorization") String token) {
+        memberService.singOut(token);
+        return SuccessResponse.ok();
+    }
+
+    @DeleteMapping("/auth/delete/{memberId}")
+    public SuccessResponse deleteMember(@PathVariable("memberId") Long memberId) {
+        memberService.deleteMember(memberId);
+        return SuccessResponse.ok();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.member.controller;
 
+import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
 import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
@@ -13,60 +14,53 @@ import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/manager")
+@RequestMapping("/v1")
 @RequiredArgsConstructor
 public class ManagerController {
 
     private final MemberService memberService;
 
-    @PostMapping
+    @PostMapping("/auth/signup")
     public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
         MailResponseDto response = memberService.saveMember(requestDto);
         return new SuccessResponse<>(response);
     }
 
-    @PostMapping("/signIn")
+    @PostMapping("/auth/signin")
     public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto) {
         SignInResponseDto signInResponseDto = memberService.signIn(requestDto);
         return new SuccessResponse<>(signInResponseDto);
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/auth/refresh")
     public SuccessResponse<JwtToken> refreshToken(@RequestBody RefreshTokenRequestDto requestDto) {
         JwtToken jwtToken = memberService.refreshToken(requestDto);
         return new SuccessResponse<>(jwtToken);
     }
 
-    @GetMapping("/signOut")
+    @GetMapping("/auth/signout")
     public SuccessResponse signOut(@RequestHeader("Authorization") String token) {
         memberService.singOut(token);
         return SuccessResponse.ok();
     }
 
-    @GetMapping("/unauthorized")
+    @GetMapping("/admin/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
         List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
         return new SuccessResponse<>(response);
     }
 
-    @GetMapping("/{nickName}")
+    @GetMapping("/normal/validate/{nickName}")
     public SuccessResponse<CheckNickNameResponseDto> checkNickName(@PathVariable("nickName") String nickName) {
         memberService.validateNickname(nickName);
         CheckNickNameResponseDto response = new CheckNickNameResponseDto(nickName);
         return new SuccessResponse<>(response, nickName + " 사용가능합니다.");
     }
 
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping("/auth/delete/{memberId}")
     public SuccessResponse deleteMember(@PathVariable("memberId") Long memberId) {
         memberService.deleteMember(memberId);
         return SuccessResponse.ok();
@@ -76,5 +70,20 @@ public class ManagerController {
     @GetMapping("/test")
     public String test() {
         return "test";
+    }
+
+    @PostMapping("/normal/authenticate/email")
+    public SuccessResponse findPassword(@RequestBody ValidateEmailReq requestDto) {
+
+        memberService.verifyEmail(requestDto);
+
+        return SuccessResponse.ok("이메일로 인증 번호가 전송되었습니다!");
+    }
+
+    @GetMapping("/normal/verify/number")
+    public SuccessResponse verifyNumber(@RequestBody ValidateEmailReq requestDto) {
+        memberService.verityNumber(requestDto);
+
+        return SuccessResponse.ok("인증되었습니다!");
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -20,25 +20,6 @@ public class ManagerController {
 
     private final MemberService memberService;
 
-    @GetMapping("/admin/unauthorized")
-    public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
-        List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
-        return new SuccessResponse<>(response);
-    }
-
-    @GetMapping("/normal/validate/{nickName}")
-    public SuccessResponse<CheckNickNameResponseDto> checkNickName(@PathVariable("nickName") String nickName) {
-        memberService.validateNickname(nickName);
-        CheckNickNameResponseDto response = new CheckNickNameResponseDto(nickName);
-        return new SuccessResponse<>(response, nickName + " 사용가능합니다.");
-    }
-
-    // ci/cd 이후 배포 성공 테스트용 엔드포인트
-    @GetMapping("/test")
-    public String test() {
-        return "test";
-    }
-
     @PostMapping("/normal/authenticate/email")
     public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto) {
 
@@ -54,10 +35,37 @@ public class ManagerController {
         return SuccessResponse.ok("인증되었습니다!");
     }
 
+    @GetMapping("/normal/upgrade/{memberId}")
+    public SuccessResponse updateAuthentication(@PathVariable("memberId") String memberId) {
+        memberService.updateAuthentication(memberId);
+
+        return new SuccessResponse("update Success.");
+    }
+
+    @GetMapping("/normal/validate/{nickName}")
+    public SuccessResponse<CheckNickNameResponseDto> checkNickName(@PathVariable("nickName") String nickName) {
+        memberService.validateNickname(nickName);
+        CheckNickNameResponseDto response = new CheckNickNameResponseDto(nickName);
+        return new SuccessResponse<>(response, nickName + " 사용가능합니다.");
+    }
+
+    @GetMapping("/admin/unauthorized")
+    public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
+        List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
+        return new SuccessResponse<>(response);
+    }
+
+    // ci/cd 이후 배포 성공 테스트용 엔드포인트
+    @GetMapping("/test")
+    public String test() {
+        return "test";
+    }
+
     @PutMapping("/normal/reset/password")
     public SuccessResponse resetPassword(@RequestBody ResetPasswordReq requestDto) {
         memberService.resetPassword(requestDto);
 
         return SuccessResponse.ok("비밀번호가 재설정되었습니다.\n 다시 로그인해주세요!");
     }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -20,30 +20,6 @@ public class ManagerController {
 
     private final MemberService memberService;
 
-    @PostMapping("/auth/signup")
-    public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
-        MailResponseDto response = memberService.saveMember(requestDto);
-        return new SuccessResponse<>(response);
-    }
-
-    @PostMapping("/auth/signin")
-    public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto) {
-        SignInResponseDto signInResponseDto = memberService.signIn(requestDto);
-        return new SuccessResponse<>(signInResponseDto);
-    }
-
-    @PostMapping("/auth/refresh")
-    public SuccessResponse<JwtToken> refreshToken(@RequestBody RefreshTokenRequestDto requestDto) {
-        JwtToken jwtToken = memberService.refreshToken(requestDto);
-        return new SuccessResponse<>(jwtToken);
-    }
-
-    @GetMapping("/auth/signout")
-    public SuccessResponse signOut(@RequestHeader("Authorization") String token) {
-        memberService.singOut(token);
-        return SuccessResponse.ok();
-    }
-
     @GetMapping("/admin/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
         List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
@@ -55,12 +31,6 @@ public class ManagerController {
         memberService.validateNickname(nickName);
         CheckNickNameResponseDto response = new CheckNickNameResponseDto(nickName);
         return new SuccessResponse<>(response, nickName + " 사용가능합니다.");
-    }
-
-    @DeleteMapping("/auth/delete/{memberId}")
-    public SuccessResponse deleteMember(@PathVariable("memberId") Long memberId) {
-        memberService.deleteMember(memberId);
-        return SuccessResponse.ok();
     }
 
     // ci/cd 이후 배포 성공 테스트용 엔드포인트

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -1,9 +1,6 @@
 package com.tave.tavewebsite.domain.member.controller;
 
-import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
-import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.*;
 import com.tave.tavewebsite.domain.member.dto.response.CheckNickNameResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
@@ -73,9 +70,9 @@ public class ManagerController {
     }
 
     @PostMapping("/normal/authenticate/email")
-    public SuccessResponse findPassword(@RequestBody ValidateEmailReq requestDto) {
+    public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto) {
 
-        memberService.verifyEmail(requestDto);
+        memberService.sendMessage(requestDto);
 
         return SuccessResponse.ok("이메일로 인증 번호가 전송되었습니다!");
     }
@@ -85,5 +82,12 @@ public class ManagerController {
         memberService.verityNumber(requestDto);
 
         return SuccessResponse.ok("인증되었습니다!");
+    }
+
+    @PutMapping("/normal/reset/password")
+    public SuccessResponse resetPassword(@RequestBody ResetPasswordReq requestDto) {
+        memberService.resetPassword(requestDto);
+
+        return SuccessResponse.ok("비밀번호가 재설정되었습니다.\n 다시 로그인해주세요!");
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetPasswordReq.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetPasswordReq.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.member.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record ResetPasswordReq(
+        String nickname,
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\W).+$",
+                message = "비밀번호는 8자 이상이어야 하며, 대문자, 소문자, 특수문자를 포함해야 합니다.")
+        String password,
+        String validatedPassword
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ValidateEmailReq.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ValidateEmailReq.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.member.dto.request;
+
+public record ValidateEmailReq(
+        String nickname,
+        String email,
+        String number
+){
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
@@ -96,4 +96,8 @@ public class Member extends BaseEntity {
                 .department(registerManagerRequestDto.department())
                 .build();
     }
+
+    public void update(String validatedPassword, PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(validatedPassword);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.member.entity;
 
+import static com.tave.tavewebsite.domain.member.entity.RoleType.MANAGER;
 import static com.tave.tavewebsite.domain.member.entity.RoleType.UNAUTHORIZED_MANAGER;
 
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
@@ -99,5 +100,9 @@ public class Member extends BaseEntity {
 
     public void update(String validatedPassword, PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(validatedPassword);
+    }
+
+    public void updateRole() {
+        this.role = MANAGER;
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
@@ -9,7 +9,9 @@ public enum ErrorMessage {
 
     NOT_FOUNT_USER(400, "유저를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(400, "중복되는 이메일입니다."),
-    DUPLICATE_NICKNAME(400, "이미 사용중인 아이디입니다. 다른 아이디로 가입해주세요.");
+    DUPLICATE_NICKNAME(400, "이미 사용중인 아이디입니다. 다른 아이디로 가입해주세요."),
+    _NOT_MATCHED_VERIFIED_NUMBER(400, "인증 번호가 일치하지 않습니다."),
+    _EXPIRED_NUMBER(401, "인증번호의 만료시간이 지났습니다.");
 
     final int code;
     final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
@@ -11,7 +11,8 @@ public enum ErrorMessage {
     DUPLICATE_EMAIL(400, "중복되는 이메일입니다."),
     DUPLICATE_NICKNAME(400, "이미 사용중인 아이디입니다. 다른 아이디로 가입해주세요."),
     _NOT_MATCHED_VERIFIED_NUMBER(400, "인증 번호가 일치하지 않습니다."),
-    _EXPIRED_NUMBER(401, "인증번호의 만료시간이 지났습니다.");
+    _EXPIRED_NUMBER(401, "인증번호의 만료시간이 지났습니다."),
+    _NOT_MATCHED_PASSWORD(400, "비밀번호가 일치하지 않습니다.");
 
     final int code;
     final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/ExpiredNumberException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/ExpiredNumberException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.member.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.member.exception.ErrorMessage._EXPIRED_NUMBER;
+
+public class ExpiredNumberException extends BaseErrorException {
+    public ExpiredNumberException() {
+        super(_EXPIRED_NUMBER.getCode(), _EXPIRED_NUMBER.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/NotMatchedNumberException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/NotMatchedNumberException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.member.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.member.exception.ErrorMessage._NOT_MATCHED_VERIFIED_NUMBER;
+
+public class NotMatchedNumberException extends BaseErrorException {
+    public NotMatchedNumberException() {
+        super(_NOT_MATCHED_VERIFIED_NUMBER.getCode(), _NOT_MATCHED_VERIFIED_NUMBER.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/NotMatchedPassword.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/NotMatchedPassword.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.member.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.member.exception.ErrorMessage._NOT_MATCHED_PASSWORD;
+
+public class NotMatchedPassword extends BaseErrorException {
+    public NotMatchedPassword() {
+        super(_NOT_MATCHED_PASSWORD.getCode(), _NOT_MATCHED_PASSWORD.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -2,15 +2,14 @@ package com.tave.tavewebsite.domain.member.service;
 
 import static com.tave.tavewebsite.domain.member.entity.RoleType.UNAUTHORIZED_MANAGER;
 
+import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
 import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
 import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
 import com.tave.tavewebsite.domain.member.entity.Member;
-import com.tave.tavewebsite.domain.member.exception.DuplicateEmailException;
-import com.tave.tavewebsite.domain.member.exception.DuplicateNicknameException;
-import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
+import com.tave.tavewebsite.domain.member.exception.*;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
 import com.tave.tavewebsite.global.mail.service.MailService;
@@ -105,5 +104,25 @@ public class MemberService {
         return jwtToken;
     }
 
+    public void verifyEmail(ValidateEmailReq req) {
+        validateNickname(req.nickname());
+        validateEmail(req.email());
+
+        mailService.sendAuthenticationCode(req.email());
+    }
+
+    public void verityNumber(ValidateEmailReq req){
+        validateEmail(req.email());
+        String validatedNumber = (String) redisUtil.get(req.email());
+
+        if(!req.number().equals(validatedNumber)){
+            throw new NotMatchedNumberException();
+        }
+        else if(redisUtil.checkExpired(req.email()) <= 0 || redisUtil.checkExpired(req.email()) == null){
+            throw new ExpiredNumberException();
+        }
+
+        redisUtil.delete(req.email());
+    }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -133,4 +133,10 @@ public class MemberService {
         memberRepository.save(member);
     }
 
+    public void updateAuthentication(String memberId){
+        Long id = Long.valueOf(memberId);
+        Member member = memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
+        member.updateRole();
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/global/mail/service/MailService.java
+++ b/src/main/java/com/tave/tavewebsite/global/mail/service/MailService.java
@@ -4,6 +4,7 @@ package com.tave.tavewebsite.global.mail.service;
 import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
 import com.tave.tavewebsite.global.mail.exception.FailCreateMailException;
 import com.tave.tavewebsite.global.mail.exception.FailMailSendException;
+import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -12,16 +13,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Random;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MailService {
 
+    private final RedisUtil redisUtil;
+    private final TemplateEngine templateEngine;
     private final JavaMailSender emailSender;
     private final String SUCCESS_SIGN_UP = "[TAVE 관리자 홈페이지] 가입 신청 완료";
+    private final String SEND_AUTHENTICATION_CODE = "[TAVE 관리자 홈페이지] 인증번호 발송 안내입니다.";
 
     @Value("${spring.mail.username}")
     private String from;
@@ -47,7 +54,7 @@ public class MailService {
         MimeMessage message = emailSender.createMimeMessage();
         message.addRecipients(Message.RecipientType.TO, to);
         // 이메일 제목
-        String msgg = ManagerSingUpHtml(message, SUCCESS_SIGN_UP);
+        String msgg = ManagerSignUpHtml(message, SUCCESS_SIGN_UP);
 
         message.setText(msgg, "utf-8", "html");
         // 보내는 사람의 이메일 주소, 보내는 사람 이름
@@ -56,7 +63,7 @@ public class MailService {
         return message;
     }
 
-    private String ManagerSingUpHtml(MimeMessage message, String subject) throws MessagingException {
+    private String ManagerSignUpHtml(MimeMessage message, String subject) throws MessagingException {
         message.setSubject(subject);
 
         String msgg = "";
@@ -71,5 +78,47 @@ public class MailService {
         return msgg;
     }
 
+
+    public MailResponseDto sendAuthenticationCode(String to){
+        String randomCode = generateCode();
+
+        MimeMessage message;
+        try {
+            message = createAuthenticationMessage(to, randomCode); // "to" 로 관리자 회원가입 신청메일 발송
+            emailSender.send(message);
+            redisUtil.set(to, randomCode, 3);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new FailCreateMailException(); // message를 생성하는 경우에 발생한 예외 (서버 문제)
+        } catch (FailMailSendException e) {
+            throw new FailMailSendException(); // Mail을 발송할때 생긴 예외
+        }
+
+        return new MailResponseDto(to + " 관리자 회원가입 신청 완료");
+    }
+
+    private String generateCode() {
+        Random random = new Random();
+        return String.format("%06d", random.nextInt(1000000)); // 6자리의 랜덤한 코드를 만든다.
+    }
+
+    // 메일 내용 작성
+    private MimeMessage createAuthenticationMessage(String to, String randomCode)
+            throws MessagingException, UnsupportedEncodingException {
+
+        MimeMessage message = emailSender.createMimeMessage();
+        message.addRecipients(Message.RecipientType.TO, to);
+        message.setSubject(SEND_AUTHENTICATION_CODE);
+
+
+        Context context = new Context();
+        context.setVariable("randomCode", randomCode);
+
+        String msgg = templateEngine.process("email-verification", context);
+
+        message.setText(msgg, "utf-8", "html");
+        message.setFrom(from);
+
+        return message;
+    }
 
 }

--- a/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
@@ -43,4 +43,12 @@ public class RedisUtil {
     public boolean hasKeyBlackList(String key) {
         return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
     }
+
+    public Long checkExpired(String key) {
+        Long ttl = redisTemplate.getExpire(key);
+        if (ttl == null) {
+            throw new IllegalStateException("Unable to fetch TTL for key: " + key);
+        }
+        return ttl;
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
@@ -46,9 +46,6 @@ public class RedisUtil {
 
     public Long checkExpired(String key) {
         Long ttl = redisTemplate.getExpire(key);
-        if (ttl == null) {
-            throw new IllegalStateException("Unable to fetch TTL for key: " + key);
-        }
         return ttl;
     }
 }

--- a/src/main/resources/templates/email-verification.html
+++ b/src/main/resources/templates/email-verification.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>이메일 인증</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: Arial, sans-serif;
+            background: linear-gradient(to bottom, #1e90ff, #87ceeb);
+            color: white;
+            text-align: center;
+            padding: 20px;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 10px;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+        }
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 20px;
+        }
+        .code-container {
+            display: inline-block;
+            background: linear-gradient(to right, #4facfe, #00f2fe);
+            color: white;
+            padding: 15px 30px;
+            border-radius: 8px;
+            font-size: 1.8rem;
+            font-weight: bold;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        }
+        .footer {
+            margin-top: 20px;
+            font-size: 0.9rem;
+            color: rgba(255, 255, 255, 0.8);
+        }
+    </style>
+</head>
+<body>
+<h1>안녕하세요</h1>
+<p>이메일 인증을 위해 아래 인증 코드를 입력하세요:</p>
+<div class="code-container">[[${randomCode}]]</div>
+<div class="footer">
+    <p>감사합니다.</p>
+    <p>&copy; 2024 Your Company Name. All rights reserved.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## ➕ 연관된 이슈
> #34
> Close #34 

## 📑 작업 내용
> 이메일 인증을 통한 비밀번호 재설정을 구현
> 이메일로 인증번호 전송 시 필요한 html 구현
> MemberController에 대한 api를 회의를 토대로 수정

## ✂️ 스크린샷 (선택)
> 비밀번호 설정에 필요한 정보를 입력하여 메일을 보내면 다음과 같은 메일 형식이 전송됩니다.(html 추후 수정 예정)
<img width="434" alt="image" src="https://github.com/user-attachments/assets/d8c6b628-0685-4e3a-a11c-b5d922231337">


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
