### PR TITLE
[Feat] 프로젝트 crud 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -20,8 +20,8 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @PostMapping("/manager/project")
-    public SuccessResponse createProject(@RequestPart @Valid ProjectRequestDto requestDto, @RequestPart MultipartFile imageFile) {
-        projectService.createProject(requestDto, imageFile);
+    public SuccessResponse createProject(@RequestPart @Valid ProjectRequestDto req, @RequestPart MultipartFile imageFile) {
+        projectService.createProject(req, imageFile);
         return SuccessResponse.ok(SuccessMessage.PROJECT_CREATE.getMessage());
     }
 
@@ -36,9 +36,9 @@ public class ProjectController {
 
     @PutMapping("/manager/project/{projectId}")
     public SuccessResponse updateProject(@PathVariable Long projectId,
-                                         @RequestPart @Valid ProjectRequestDto requestDto,
+                                         @RequestPart @Valid ProjectRequestDto req,
                                          @RequestPart MultipartFile imageFile) {
-        projectService.updateProject(projectId, requestDto, imageFile);
+        projectService.updateProject(projectId, req, imageFile);
         return SuccessResponse.ok(SuccessMessage.PROJECT_UPDATE.getMessage());
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -12,8 +12,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/v1")
 @RequiredArgsConstructor

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -28,4 +28,11 @@ public class ProjectController {
         List<ProjectResponseDto> response = projectService.getAllProjects();
         return new SuccessResponse<>(response);
     }
+
+    @GetMapping("/{projectId}")
+    public SuccessResponse<ProjectResponseDto> getProjectById(@PathVariable Long projectId) {
+        ProjectResponseDto response = projectService.getProjectById(projectId);
+        return new SuccessResponse<>(response);
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -21,19 +21,19 @@ public class ProjectController {
     @PostMapping("/manager/project")
     public SuccessResponse createProject(@RequestPart @Valid ProjectRequestDto requestDto, @RequestPart MultipartFile imageFile) {
         projectService.createProject(requestDto, imageFile);
-        return SuccessResponse.ok("프로젝트가 생성되었습니다.");
+        return SuccessResponse.ok(SuccessMessage.PROJECT_CREATE.getMessage());
     }
 
     @GetMapping("/normal/project")
     public SuccessResponse<List<ProjectResponseDto>> getAllProjects() {
         List<ProjectResponseDto> response = projectService.getAllProjects();
-        return new SuccessResponse<>(response);
+        return new SuccessResponse<>(response, SuccessMessage.PROJECT_READ.getMessage());
     }
 
     @GetMapping("/normal/project/{projectId}")
     public SuccessResponse<ProjectResponseDto> getProjectById(@PathVariable Long projectId) {
         ProjectResponseDto response = projectService.getProjectById(projectId);
-        return new SuccessResponse<>(response);
+        return new SuccessResponse<>(response, SuccessMessage.PROJECT_READ.getMessage());
     }
 
     @PutMapping("/manager/project/{projectId}")
@@ -41,12 +41,12 @@ public class ProjectController {
                                          @RequestPart @Valid ProjectRequestDto requestDto,
                                          @RequestPart MultipartFile imageFile) {
         projectService.updateProject(projectId, requestDto, imageFile);
-        return SuccessResponse.ok("프로젝트가 수정되었습니다.");
+        return SuccessResponse.ok(SuccessMessage.PROJECT_UPDATE.getMessage());
     }
 
     @DeleteMapping("/manager/project/{projectId}")
     public SuccessResponse deleteProject(@PathVariable Long projectId) {
         projectService.deleteProject(projectId);
-        return SuccessResponse.ok("프로젝트가 성공적으로 삭제되었습니다.");
+        return SuccessResponse.ok(SuccessMessage.PROJECT_DELETE.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -7,43 +7,46 @@ import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/project")
+@RequestMapping("/v1")
 @RequiredArgsConstructor
 public class ProjectController {
 
     private final ProjectService projectService;
 
-    @PostMapping
-    public SuccessResponse<ProjectResponseDto> createProject(@RequestBody @Valid ProjectRequestDto requestDto) {
-        ProjectResponseDto response = projectService.createProject(requestDto);
-        return new SuccessResponse<>(response);
+    @PostMapping("/manager/project")
+    public SuccessResponse createProject(@RequestPart @Valid ProjectRequestDto requestDto, @RequestPart MultipartFile imageFile) {
+        projectService.createProject(requestDto, imageFile);
+        return SuccessResponse.ok("프로젝트가 생성되었습니다.");
     }
 
-    @GetMapping
+    @GetMapping("/normal/project")
     public SuccessResponse<List<ProjectResponseDto>> getAllProjects() {
         List<ProjectResponseDto> response = projectService.getAllProjects();
         return new SuccessResponse<>(response);
     }
 
-    @GetMapping("/{projectId}")
+    @GetMapping("/normal/project/{projectId}")
     public SuccessResponse<ProjectResponseDto> getProjectById(@PathVariable Long projectId) {
         ProjectResponseDto response = projectService.getProjectById(projectId);
         return new SuccessResponse<>(response);
     }
 
-    @PutMapping("/{projectId}")
-    public SuccessResponse<ProjectResponseDto> updateProject(@PathVariable Long projectId, @RequestBody @Valid ProjectRequestDto requestDto) {
-        ProjectResponseDto response = projectService.updateProject(projectId, requestDto);
-        return new SuccessResponse<>(response);
+    @PutMapping("/manager/project/{projectId}")
+    public SuccessResponse updateProject(@PathVariable Long projectId,
+                                         @RequestPart @Valid ProjectRequestDto requestDto,
+                                         @RequestPart MultipartFile imageFile) {
+        projectService.updateProject(projectId, requestDto, imageFile);
+        return SuccessResponse.ok("프로젝트가 수정되었습니다.");
     }
 
-    @DeleteMapping("/{projectId}")
+    @DeleteMapping("/manager/project/{projectId}")
     public SuccessResponse deleteProject(@PathVariable Long projectId) {
         projectService.deleteProject(projectId);
-        return new SuccessResponse<>(null);
+        return SuccessResponse.ok("프로젝트가 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -6,10 +6,9 @@ import com.tave.tavewebsite.domain.project.service.ProjectService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/project")
@@ -21,6 +20,12 @@ public class ProjectController {
     @PostMapping
     public SuccessResponse<ProjectResponseDto> createProject(@RequestBody @Valid ProjectRequestDto requestDto) {
         ProjectResponseDto response = projectService.createProject(requestDto);
+        return new SuccessResponse<>(response);
+    }
+
+    @GetMapping
+    public SuccessResponse<List<ProjectResponseDto>> getAllProjects() {
+        List<ProjectResponseDto> response = projectService.getAllProjects();
         return new SuccessResponse<>(response);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -1,7 +1,13 @@
 package com.tave.tavewebsite.domain.project.controller;
 
+import com.tave.tavewebsite.domain.project.dto.request.ProjectRequestDto;
+import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
 import com.tave.tavewebsite.domain.project.service.ProjectService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,6 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/project")
 @RequiredArgsConstructor
 public class ProjectController {
+
     private final ProjectService projectService;
 
+    @PostMapping
+    public SuccessResponse<ProjectResponseDto> createProject(@RequestBody @Valid ProjectRequestDto requestDto) {
+        ProjectResponseDto response = projectService.createProject(requestDto);
+        return new SuccessResponse<>(response);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -35,4 +35,9 @@ public class ProjectController {
         return new SuccessResponse<>(response);
     }
 
+    @PutMapping("/{projectId}")
+    public SuccessResponse<ProjectResponseDto> updateProject(@PathVariable Long projectId, @RequestBody @Valid ProjectRequestDto requestDto) {
+        ProjectResponseDto response = projectService.updateProject(projectId, requestDto);
+        return new SuccessResponse<>(response);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.project.controller;
+
+import com.tave.tavewebsite.domain.project.service.ProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/project")
+@RequiredArgsConstructor
+public class ProjectController {
+    private final ProjectService projectService;
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -6,6 +6,9 @@ import com.tave.tavewebsite.domain.project.service.ProjectService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,16 +27,13 @@ public class ProjectController {
         return SuccessResponse.ok(SuccessMessage.PROJECT_CREATE.getMessage());
     }
 
-    @GetMapping("/normal/project")
-    public SuccessResponse<List<ProjectResponseDto>> getAllProjects() {
-        List<ProjectResponseDto> response = projectService.getAllProjects();
-        return new SuccessResponse<>(response, SuccessMessage.PROJECT_READ.getMessage());
-    }
 
-    @GetMapping("/normal/project/{projectId}")
-    public SuccessResponse<ProjectResponseDto> getProjectById(@PathVariable Long projectId) {
-        ProjectResponseDto response = projectService.getProjectById(projectId);
-        return new SuccessResponse<>(response, SuccessMessage.PROJECT_READ.getMessage());
+    @GetMapping("/normal/project")
+    public SuccessResponse<Page<ProjectResponseDto>> getProjects(@PageableDefault(size = 8) Pageable pageable,
+                                                                 @RequestParam(defaultValue = "ALL", name = "generation") String generation,
+                                                                 @RequestParam(defaultValue = "ALL", name = "field") String field) {
+        Page<ProjectResponseDto> projects = projectService.getProjects(generation, field, pageable);
+        return new SuccessResponse<>(projects);
     }
 
     @PutMapping("/manager/project/{projectId}")

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -40,4 +40,10 @@ public class ProjectController {
         ProjectResponseDto response = projectService.updateProject(projectId, requestDto);
         return new SuccessResponse<>(response);
     }
+
+    @DeleteMapping("/{projectId}")
+    public SuccessResponse deleteProject(@PathVariable Long projectId) {
+        projectService.deleteProject(projectId);
+        return new SuccessResponse<>(null);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/SuccessMessage.java
@@ -1,0 +1,21 @@
+package com.tave.tavewebsite.domain.project.controller;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum SuccessMessage {
+    PROJECT_CREATE("프로젝트를 생성했습니다."),
+    PROJECT_READ("프로젝트를 조회했습니다."),
+    PROJECT_UPDATE("프로젝트를 수정했습니다."),
+    PROJECT_DELETE("프로젝트를 삭제했습니다.");
+
+    private final String message;
+
+    public String getMessage(String generation) {
+        return generation +" " + message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/dto/request/ProjectRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/dto/request/ProjectRequestDto.java
@@ -29,7 +29,4 @@ public class ProjectRequestDto {
 
     @NotNull
     private String blogUrl;
-
-    @NotNull
-    private String imgUrl;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/dto/request/ProjectRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/dto/request/ProjectRequestDto.java
@@ -1,0 +1,35 @@
+package com.tave.tavewebsite.domain.project.dto.request;
+
+import com.tave.tavewebsite.global.common.FieldType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ProjectRequestDto {
+
+    @NotNull
+    @Size(min = 1, max = 30)
+    private String title;
+
+    @NotNull
+    @Size(min = 1, max = 500)
+    private String description;
+
+    @NotNull
+    @Size(min = 1, max = 5)
+    private String generation;
+
+    @NotNull
+    @Size(min = 1, max = 30)
+    private String teamName;
+
+    @NotNull
+    private FieldType field;
+
+    @NotNull
+    private String blogUrl;
+
+    @NotNull
+    private String imgUrl;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/dto/response/ProjectResponseDto.java
@@ -13,7 +13,6 @@ public class ProjectResponseDto {
     private final String teamName;
     private final FieldType field;
     private final String blogUrl;
-    private final String imgUrl;
 
     public ProjectResponseDto(Project project) {
         this.id = project.getId();
@@ -23,6 +22,5 @@ public class ProjectResponseDto {
         this.teamName = project.getTeamName();
         this.field = project.getField();
         this.blogUrl = project.getBlogUrl();
-        this.imgUrl = project.getImgUrl();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/dto/response/ProjectResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/dto/response/ProjectResponseDto.java
@@ -1,0 +1,28 @@
+package com.tave.tavewebsite.domain.project.dto.response;
+
+import com.tave.tavewebsite.domain.project.entity.Project;
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.Getter;
+
+@Getter
+public class ProjectResponseDto {
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final String generation;
+    private final String teamName;
+    private final FieldType field;
+    private final String blogUrl;
+    private final String imgUrl;
+
+    public ProjectResponseDto(Project project) {
+        this.id = project.getId();
+        this.title = project.getTitle();
+        this.description = project.getDescription();
+        this.generation = project.getGeneration();
+        this.teamName = project.getTeamName();
+        this.field = project.getField();
+        this.blogUrl = project.getBlogUrl();
+        this.imgUrl = project.getImgUrl();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
@@ -78,4 +78,14 @@ public class Project extends BaseEntity {
         this.blogUrl = blogUrl;
         this.imgUrl = imgUrl;
     }
+
+    public void update(String title, String description, String generation, String teamName, FieldType field, String blogUrl, String imgUrl) {
+        this.title = title;
+        this.description = description;
+        this.generation = generation;
+        this.teamName = teamName;
+        this.field = field;
+        this.blogUrl = blogUrl;
+        this.imgUrl = imgUrl;
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.project.entity;
 
+import com.tave.tavewebsite.domain.project.dto.request.ProjectRequestDto;
 import com.tave.tavewebsite.global.common.BaseEntity;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.persistence.*;
@@ -10,8 +11,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.URL;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -48,14 +47,6 @@ public class Project extends BaseEntity {
     @Column(nullable = false)
     private FieldType field;
 
-//    @NotNull
-//    @Column(nullable = false)
-//    private LocalDateTime startDate;
-//
-//    @NotNull
-//    @Column(nullable = false)
-//    private LocalDateTime endDate;
-
     @NotNull
     @URL
     @Column(length = 2083, nullable = false)
@@ -67,25 +58,24 @@ public class Project extends BaseEntity {
     private String imgUrl;
 
     @Builder
-    public Project(String title, String description, String generation, String teamName, FieldType field, String blogUrl, String imgUrl) {
-        this.title = title;
-        this.description = description;
-        this.generation = generation;
-        this.teamName = teamName;
-        this.field = field;
-//        this.startDate = startDate;
-//        this.endDate = endDate;
-        this.blogUrl = blogUrl;
-        this.imgUrl = imgUrl;
+    public Project(ProjectRequestDto req, URL imageUrl) {
+        this.title = req.getTitle();
+        this.description = req.getDescription();
+        this.generation = req.getGeneration();
+        this.teamName = req.getTeamName();
+        this.field = req.getField();
+        this.blogUrl = req.getBlogUrl();
+        this.imgUrl = imageUrl.toString();
     }
 
-    public void update(String title, String description, String generation, String teamName, FieldType field, String blogUrl, String imgUrl) {
-        this.title = title;
-        this.description = description;
-        this.generation = generation;
-        this.teamName = teamName;
-        this.field = field;
-        this.blogUrl = blogUrl;
-        this.imgUrl = imgUrl;
+    public Project updateProject(ProjectRequestDto req, URL imageUrl) {
+        this.title = req.getTitle();
+        this.description = req.getDescription();
+        this.generation = req.getGeneration();
+        this.teamName = req.getTeamName();
+        this.field = req.getField();
+        this.blogUrl = req.getBlogUrl();
+        this.imgUrl = imageUrl.toString();
+        return this;
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
@@ -10,7 +10,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.validator.constraints.URL;
+
+import java.net.URL;
 
 @Entity
 @Getter
@@ -48,12 +49,10 @@ public class Project extends BaseEntity {
     private FieldType field;
 
     @NotNull
-    @URL
     @Column(length = 2083, nullable = false)
     private String blogUrl;
 
     @NotNull
-    @URL
     @Column(length = 2083, nullable = false)
     private String imgUrl;
 

--- a/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/entity/Project.java
@@ -48,13 +48,13 @@ public class Project extends BaseEntity {
     @Column(nullable = false)
     private FieldType field;
 
-    @NotNull
-    @Column(nullable = false)
-    private LocalDateTime startDate;
-
-    @NotNull
-    @Column(nullable = false)
-    private LocalDateTime endDate;
+//    @NotNull
+//    @Column(nullable = false)
+//    private LocalDateTime startDate;
+//
+//    @NotNull
+//    @Column(nullable = false)
+//    private LocalDateTime endDate;
 
     @NotNull
     @URL
@@ -67,14 +67,14 @@ public class Project extends BaseEntity {
     private String imgUrl;
 
     @Builder
-    public Project(String title, String description, String generation, String teamName, FieldType field, LocalDateTime startDate, LocalDateTime endDate, String blogUrl, String imgUrl) {
+    public Project(String title, String description, String generation, String teamName, FieldType field, String blogUrl, String imgUrl) {
         this.title = title;
         this.description = description;
         this.generation = generation;
         this.teamName = teamName;
         this.field = field;
-        this.startDate = startDate;
-        this.endDate = endDate;
+//        this.startDate = startDate;
+//        this.endDate = endDate;
         this.blogUrl = blogUrl;
         this.imgUrl = imgUrl;
     }

--- a/src/main/java/com/tave/tavewebsite/domain/project/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/exception/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.project.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    PROJECT_NOT_FOUND(400, "프로젝트를 찾을 수 없습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/exception/ProjectNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/exception/ProjectNotFoundException.java
@@ -5,7 +5,7 @@ import com.tave.tavewebsite.global.exception.BaseErrorException;
 import static com.tave.tavewebsite.domain.project.exception.ErrorMessage.PROJECT_NOT_FOUND;
 
 public class ProjectNotFoundException extends BaseErrorException {
-    public ProjectNotFoundException(String message) {
+    public ProjectNotFoundException() {
         super(PROJECT_NOT_FOUND.getCode(), PROJECT_NOT_FOUND.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/exception/ProjectNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/exception/ProjectNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.project.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.project.exception.ErrorMessage.PROJECT_NOT_FOUND;
+
+public class ProjectNotFoundException extends BaseErrorException {
+    public ProjectNotFoundException(String message) {
+        super(PROJECT_NOT_FOUND.getCode(), PROJECT_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/repository/CustomProjectRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/repository/CustomProjectRepository.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.project.repository;
+
+import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomProjectRepository {
+    Page<ProjectResponseDto> findProjectByGenerationAndField(String generation, String field, Pageable pageable);
+
+    Page<ProjectResponseDto> findProjectByGeneration(String generation, Pageable pageable);
+
+    Page<ProjectResponseDto> findProjectByField(String field, Pageable pageable);
+
+    Page<ProjectResponseDto> findAllProjects(Pageable pageable);
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/repository/CustomProjectRepositoryImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/repository/CustomProjectRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.tave.tavewebsite.domain.project.repository;
+
+import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
+import com.tave.tavewebsite.domain.project.entity.Project;
+import com.tave.tavewebsite.global.common.FieldType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@Slf4j
+public class CustomProjectRepositoryImpl implements CustomProjectRepository {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Page<ProjectResponseDto> findProjectByGenerationAndField(String generation, String field, Pageable pageable) {
+        List<Project> projects = em.createQuery("select p from Project p where p.field=:field and p.generation = :generation", Project.class)
+                .setParameter("field", FieldType.valueOf(field))
+                .setParameter("generation", generation)
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+
+        return getResult(projects, pageable);
+    }
+
+    @Override
+    public Page<ProjectResponseDto> findProjectByGeneration(String generation, Pageable pageable) {
+        List<Project> projects = em.createQuery("select p from Project p where p.generation = :generation", Project.class)
+                .setParameter("generation", generation)
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+
+        return getResult(projects, pageable);
+    }
+
+    @Override
+    public Page<ProjectResponseDto> findProjectByField(String field, Pageable pageable) {
+        List<Project> projects = em.createQuery("select p from Project p where p.field = :field", Project.class)
+                .setParameter("field", FieldType.valueOf(field))
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+
+        return getResult(projects, pageable);
+    }
+
+    @Override
+    public Page<ProjectResponseDto> findAllProjects(Pageable pageable) {
+        // 전체 프로젝트를 가져오는 쿼리 수정
+        List<Project> projects = em.createQuery("select p from Project p order by p.createdAt", Project.class)
+                .setMaxResults(pageable.getPageSize())
+                .getResultList();
+
+        log.info("findAllProjects: {}", projects.size());
+
+        return getResult(projects, pageable);
+    }
+
+    private Page<ProjectResponseDto> getResult(List<Project> projects, Pageable pageable) {
+        List<ProjectResponseDto> projectResponseDtos = projects.stream()
+                .map(ProjectResponseDto::new) // Project 객체를 매개변수로 받는 생성자를 사용
+                .toList();
+
+        // 페이지네이션을 위한 반환
+        return new PageImpl<>(projectResponseDtos, pageable, projects.size());
+    }
+}
+

--- a/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
@@ -3,6 +3,6 @@ package com.tave.tavewebsite.domain.project.repository;
 import com.tave.tavewebsite.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, CustomProjectRepository {
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository {
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/repository/ProjectRepository.java
@@ -1,7 +1,8 @@
 package com.tave.tavewebsite.domain.project.repository;
 
+import com.tave.tavewebsite.domain.project.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProjectRepository extends JpaRepository {
+public interface ProjectRepository extends JpaRepository<Project, Long> {
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -26,6 +29,14 @@ public class ProjectService {
                 .build();
         projectRepository.save(project);
         return new ProjectResponseDto(project);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectResponseDto> getAllProjects() {
+        return projectRepository.findAll()
+                .stream()
+                .map(ProjectResponseDto::new)
+                .collect(Collectors.toList());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -56,4 +56,10 @@ public class ProjectService {
 
         return new ProjectResponseDto(project);
     }
+
+    public void deleteProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
+        projectRepository.delete(project);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -46,5 +46,14 @@ public class ProjectService {
                 .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId + projectId));
         return new ProjectResponseDto(project);
     }
-    
+
+    public ProjectResponseDto updateProject(Long projectId, ProjectRequestDto requestDto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
+
+        project.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getGeneration(),
+                requestDto.getTeamName(), requestDto.getField(), requestDto.getBlogUrl(), requestDto.getImgUrl());
+
+        return new ProjectResponseDto(project);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -1,5 +1,8 @@
 package com.tave.tavewebsite.domain.project.service;
 
+import com.tave.tavewebsite.domain.project.dto.request.ProjectRequestDto;
+import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
+import com.tave.tavewebsite.domain.project.entity.Project;
 import com.tave.tavewebsite.domain.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,5 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepository;
+
+    public ProjectResponseDto createProject(ProjectRequestDto requestDto) {
+        Project project = Project.builder()
+                .title(requestDto.getTitle())
+                .description(requestDto.getDescription())
+                .generation(requestDto.getGeneration())
+                .teamName(requestDto.getTeamName())
+                .field(requestDto.getField())
+                .blogUrl(requestDto.getBlogUrl())
+                .imgUrl(requestDto.getImgUrl())
+                .build();
+        projectRepository.save(project);
+        return new ProjectResponseDto(project);
+    }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.project.service;
+
+import com.tave.tavewebsite.domain.project.repository.ProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProjectService {
+    private final ProjectRepository projectRepository;
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.project.service;
 import com.tave.tavewebsite.domain.project.dto.request.ProjectRequestDto;
 import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
 import com.tave.tavewebsite.domain.project.entity.Project;
+import com.tave.tavewebsite.domain.project.exception.ProjectNotFoundException;
 import com.tave.tavewebsite.domain.project.repository.ProjectRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,4 +40,11 @@ public class ProjectService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public ProjectResponseDto getProjectById(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId + projectId));
+        return new ProjectResponseDto(project);
+    }
+    
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -7,66 +7,84 @@ import com.tave.tavewebsite.domain.project.exception.ProjectNotFoundException;
 import com.tave.tavewebsite.domain.project.repository.ProjectRepository;
 import com.tave.tavewebsite.global.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URL;
-import java.util.List;
-import java.util.stream.Collectors;
 
+@Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class ProjectService {
+
     private final ProjectRepository projectRepository;
     private final S3Service s3Service;
 
-    public ProjectResponseDto createProject(ProjectRequestDto requestDto, MultipartFile imageFile) {
-        URL imgUrl = s3Service.uploadImages(imageFile);
-        Project project = Project.builder()
-                .title(requestDto.getTitle())
-                .description(requestDto.getDescription())
-                .generation(requestDto.getGeneration())
-                .teamName(requestDto.getTeamName())
-                .field(requestDto.getField())
-                .blogUrl(requestDto.getBlogUrl())
-                .imgUrl(imgUrl.toString())
-                .build();
+    // 프로젝트 생성
+    public void createProject(ProjectRequestDto req, MultipartFile file) {
+        // 파일을 S3에 업로드하고 URL을 받음
+        URL url = s3Service.uploadImages(file);
+
+        // ProjectRequestDto에서 값을 추출하여 Project 엔티티 생성
+//        Project project = new Project(req.getTitle(), req.getDescription(), req.getGeneration(), req.getFieldType(), url);
+        Project project = new Project(req, url);
+
         projectRepository.save(project);
-        return new ProjectResponseDto(project);
     }
 
+    // 프로젝트 조회
     @Transactional(readOnly = true)
-    public List<ProjectResponseDto> getAllProjects() {
-        return projectRepository.findAll()
-                .stream()
-                .map(ProjectResponseDto::new)
-                .collect(Collectors.toList());
+    public Page<ProjectResponseDto> getProjects(String generation, String field, Pageable pageable) {
+        Page<ProjectResponseDto> projects;
+
+        try {
+            log.info("field: {}, generation: {}", field, generation);
+
+            // 필드와 세대 조건에 맞는 프로젝트 찾기
+            if ("ALL".equals(generation) && "ALL".equals(field)) {
+                projects = projectRepository.findAllProjects(pageable);
+            } else if ("ALL".equals(generation)) {
+                projects = projectRepository.findProjectByField(field, pageable);
+            } else if ("ALL".equals(field)) {
+                projects = projectRepository.findProjectByGeneration(generation, pageable);
+            } else {
+                projects = projectRepository.findProjectByGenerationAndField(generation, field, pageable);
+            }
+        } catch (Exception e) {
+            // 예외 발생 시 PROJECT_NOT_FOUND 예외 던지기
+            throw new ProjectNotFoundException();
+        }
+
+        return projects;
     }
 
-    @Transactional(readOnly = true)
-    public ProjectResponseDto getProjectById(Long projectId) {
+    // 프로젝트 수정
+    public void updateProject(Long projectId, ProjectRequestDto req, MultipartFile file) {
+        // 프로젝트가 존재하는지 확인
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
-        return new ProjectResponseDto(project);
+                .orElseThrow(ProjectNotFoundException::new); // ProjectNotFoundException 발생
+
+        // 파일을 S3에 업로드하고 URL을 받음
+        URL url = s3Service.uploadImages(file);
+
+        // 프로젝트 수정
+        project.updateProject(req, url);
     }
 
-    public ProjectResponseDto updateProject(Long projectId, ProjectRequestDto requestDto, MultipartFile imageFile) {
-        Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
-
-        URL imgUrl = s3Service.uploadImages(imageFile);
-        project.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getGeneration(),
-                requestDto.getTeamName(), requestDto.getField(), requestDto.getBlogUrl(), imgUrl.toString());
-
-        return new ProjectResponseDto(project);
-    }
-
+    // 프로젝트 삭제
     public void deleteProject(Long projectId) {
+        // 프로젝트가 존재하는지 확인
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
+                .orElseThrow(ProjectNotFoundException::new);
+
+        // S3에서 이미지 삭제
         s3Service.deleteImage(project.getImgUrl());
+
+        // 프로젝트 삭제
         projectRepository.delete(project);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -5,10 +5,13 @@ import com.tave.tavewebsite.domain.project.dto.response.ProjectResponseDto;
 import com.tave.tavewebsite.domain.project.entity.Project;
 import com.tave.tavewebsite.domain.project.exception.ProjectNotFoundException;
 import com.tave.tavewebsite.domain.project.repository.ProjectRepository;
+import com.tave.tavewebsite.global.s3.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.net.URL;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,8 +20,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ProjectService {
     private final ProjectRepository projectRepository;
+    private final S3Service s3Service;
 
-    public ProjectResponseDto createProject(ProjectRequestDto requestDto) {
+    public ProjectResponseDto createProject(ProjectRequestDto requestDto, MultipartFile imageFile) {
+        URL imgUrl = s3Service.uploadImages(imageFile);
         Project project = Project.builder()
                 .title(requestDto.getTitle())
                 .description(requestDto.getDescription())
@@ -26,7 +31,7 @@ public class ProjectService {
                 .teamName(requestDto.getTeamName())
                 .field(requestDto.getField())
                 .blogUrl(requestDto.getBlogUrl())
-                .imgUrl(requestDto.getImgUrl())
+                .imgUrl(imgUrl.toString())
                 .build();
         projectRepository.save(project);
         return new ProjectResponseDto(project);
@@ -43,16 +48,17 @@ public class ProjectService {
     @Transactional(readOnly = true)
     public ProjectResponseDto getProjectById(Long projectId) {
         Project project = projectRepository.findById(projectId)
-                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId + projectId));
+                .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
         return new ProjectResponseDto(project);
     }
 
-    public ProjectResponseDto updateProject(Long projectId, ProjectRequestDto requestDto) {
+    public ProjectResponseDto updateProject(Long projectId, ProjectRequestDto requestDto, MultipartFile imageFile) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
 
+        URL imgUrl = s3Service.uploadImages(imageFile);
         project.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getGeneration(),
-                requestDto.getTeamName(), requestDto.getField(), requestDto.getBlogUrl(), requestDto.getImgUrl());
+                requestDto.getTeamName(), requestDto.getField(), requestDto.getBlogUrl(), imgUrl.toString());
 
         return new ProjectResponseDto(project);
     }
@@ -60,6 +66,7 @@ public class ProjectService {
     public void deleteProject(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new ProjectNotFoundException("Project ID: " + projectId));
+        s3Service.deleteImage(project.getImgUrl());
         projectRepository.delete(project);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/service/ProjectService.java
@@ -63,6 +63,7 @@ public class ProjectService {
     }
 
     // 프로젝트 수정
+    @Transactional
     public void updateProject(Long projectId, ProjectRequestDto req, MultipartFile file) {
         // 프로젝트가 존재하는지 확인
         Project project = projectRepository.findById(projectId)

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -4,5 +4,7 @@ public enum FieldType {
     DEEP_LEARNING,
     DATA_ANALYSIS,
     FRONTEND,
-    BACKEND
+    BACKEND,
+    ADVANCED,       // 심화
+    COLLABORATIVE   // 연합
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #26
> Close #26

## 📑 작업 내용
> - 프로젝트 crud
> - 프로젝트 조회 시 페이징 처리, 기수 또는 분야 별 조회
> - S3 이미지 업로드

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 1. update 기능 구현 시 DB에 수정사항이 반영되지 않는 문제가 있었습니다. @Transactional 어노테이션을 추가해 해당 메서드 내의 모든 DB 연산을 트랜잭션 내에서 처리하도록 하여 DB 업데이트 문제를 수정했습니다.

> - @Transactional 어노테이션을 추가하기 전에는 updateProject 메서드에서 엔티티 업데이트가 단순히 메모리에서만 이루어졌을 가능성이 있습니다. Spring은 기본적으로 DB 연산을 처리하는 메서드에 트랜잭션을 적용하지 않으면, 해당 메서드가 호출될 때 실제로 데이터베이스에 커밋되지 않을 수 있습니다. 트랜잭션을 사용함으로써 데이터베이스의 상태 일관성을 유지하고, 중간에 발생할 수 있는 오류로부터 보호하며, 엔티티의 변경 사항이 확실하게 DB에 반영되도록 보장할 수 있습니다.
> 2. 응답 메시지를 SuccessMessage 파일에서 불러오는 방식을 사용했습니다.
> - 모든 응답 메시지를 한 곳에서 관리 가능
> - 메시지의 표현이나 형식에 일관성 유지 가능
> - 유지보수 훨씬 간편