### PR TITLE
[feat] 운영진 강제 탈퇴 처리 기능 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -2,12 +2,14 @@ package com.tave.tavewebsite.domain.member.controller;
 
 import com.tave.tavewebsite.domain.member.dto.response.AuthorizedManagerResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.member.entity.RoleType;
+import com.tave.tavewebsite.domain.member.exception.NotManagerAccessException;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -21,12 +23,26 @@ public class AdminController {
     @GetMapping("/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
         List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
-        return new SuccessResponse<>(response);
+        return new SuccessResponse<>(response, SuccessMessage.UNAUTHORIZED_MEMBER_READ.getMessage());
     }
 
     @GetMapping("/authorized")
     public SuccessResponse<List<AuthorizedManagerResponseDto>> getAuthorizedAdmins() {
         List<AuthorizedManagerResponseDto> response = memberService.getAuthorizedAdmins();
-        return new SuccessResponse<>(response);
+        return new SuccessResponse<>(response, SuccessMessage.AUTHORIZED_MEMBER_READ.getMessage());
     }
+
+    @DeleteMapping("/{memberId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public SuccessResponse<Void> deleteManager(@PathVariable Long memberId) {
+        Member member = memberService.findMemberById(memberId);
+
+        if (!member.getRole().equals(RoleType.MANAGER)) {
+            throw new NotManagerAccessException();
+        }
+
+        memberService.deleteManager(memberId);
+        return new SuccessResponse<>(null, SuccessMessage.MANAGER_DELETE.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import static com.tave.tavewebsite.domain.member.controller.SuccessMessage.UNAUTHORIZED_MEMBER_READ;
+
 @RestController
 @RequestMapping("/v1/admin")
 @RequiredArgsConstructor
@@ -21,20 +23,20 @@ public class AdminController {
 
     @GetMapping("/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
-        List<UnauthorizedManagerResponseDto> response = adminService.getUnauthorizedManager();
-        return new SuccessResponse<>(response, SuccessMessage.UNAUTHORIZED_MEMBER_READ.getMessage());
+       adminService.getUnauthorizedManager();
+       return SuccessResponse.ok(SuccessMessage.UNAUTHORIZED_MEMBER_READ.getMessage());
     }
 
     @GetMapping("/authorized")
     public SuccessResponse<List<AuthorizedManagerResponseDto>> getAuthorizedAdmins() {
-        List<AuthorizedManagerResponseDto> response = adminService.getAuthorizedAdmins();
-        return new SuccessResponse<>(response, SuccessMessage.AUTHORIZED_MEMBER_READ.getMessage());
+        adminService.getAuthorizedAdmins();
+        return SuccessResponse.ok(SuccessMessage.AUTHORIZED_MEMBER_READ.getMessage());
     }
 
     @DeleteMapping("/{memberId}")
-    public SuccessResponse<Void> deleteManager(@PathVariable Long memberId) {
+    public SuccessResponse deleteManager(@PathVariable Long memberId) {
         adminService.deleteManager(memberId);
-        return new SuccessResponse<>(null, SuccessMessage.MANAGER_DELETE.getMessage());
+        return SuccessResponse.ok(SuccessMessage.MANAGER_DELETE.getMessage());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -2,17 +2,11 @@ package com.tave.tavewebsite.domain.member.controller;
 
 import com.tave.tavewebsite.domain.member.dto.response.AuthorizedManagerResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
-import com.tave.tavewebsite.domain.member.entity.Member;
-import com.tave.tavewebsite.domain.member.entity.RoleType;
-import com.tave.tavewebsite.domain.member.exception.NotManagerAccessException;
 import com.tave.tavewebsite.domain.member.service.AdminService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import static com.tave.tavewebsite.domain.member.controller.SuccessMessage.UNAUTHORIZED_MEMBER_READ;
 
 @RestController
 @RequestMapping("/v1/admin")
@@ -23,14 +17,14 @@ public class AdminController {
 
     @GetMapping("/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
-       adminService.getUnauthorizedManager();
-       return SuccessResponse.ok(SuccessMessage.UNAUTHORIZED_MEMBER_READ.getMessage());
+        List<UnauthorizedManagerResponseDto> response = adminService.getUnauthorizedManager();
+        return new SuccessResponse<>(response, SuccessMessage.UNAUTHORIZED_MEMBER_READ.getMessage());
     }
 
     @GetMapping("/authorized")
     public SuccessResponse<List<AuthorizedManagerResponseDto>> getAuthorizedAdmins() {
-        adminService.getAuthorizedAdmins();
-        return SuccessResponse.ok(SuccessMessage.AUTHORIZED_MEMBER_READ.getMessage());
+        List<AuthorizedManagerResponseDto> response = adminService.getAuthorizedAdmins();
+        return new SuccessResponse<>(response, SuccessMessage.AUTHORIZED_MEMBER_READ.getMessage());
     }
 
     @DeleteMapping("/{memberId}")

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -32,14 +32,7 @@ public class AdminController {
     }
 
     @DeleteMapping("/{memberId}")
-    @PreAuthorize("hasRole('ADMIN')")
     public SuccessResponse<Void> deleteManager(@PathVariable Long memberId) {
-        Member member = adminService.findMemberById(memberId);
-
-        if (!member.getRole().equals(RoleType.MANAGER)) {
-            throw new NotManagerAccessException();
-        }
-
         adminService.deleteManager(memberId);
         return new SuccessResponse<>(null, SuccessMessage.MANAGER_DELETE.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/SuccessMessage.java
@@ -1,0 +1,20 @@
+package com.tave.tavewebsite.domain.member.controller;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum SuccessMessage {
+    UNAUTHORIZED_MEMBER_READ("승인 대기 중인 운영진을 조회했습니다."),
+    AUTHORIZED_MEMBER_READ("승인된 운영진을 조회했습니다."),
+    MANAGER_DELETE("해당 운영진을 삭제했습니다.");
+
+    private final String message;
+
+    public String getMessage(String generation) {
+        return generation +" " + message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/AuthorizedManagerResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/AuthorizedManagerResponseDto.java
@@ -5,6 +5,7 @@ import com.tave.tavewebsite.domain.member.entity.JobType;
 import com.tave.tavewebsite.domain.member.entity.Member;
 
 public record AuthorizedManagerResponseDto(
+        Long id,
         String username,
         String nickname,
         DepartmentType department,
@@ -14,6 +15,7 @@ public record AuthorizedManagerResponseDto(
 ) {
     public static AuthorizedManagerResponseDto fromEntity(Member member) {
         return new AuthorizedManagerResponseDto(
+                member.getId(),
                 member.getUsername(),
                 member.getNickname(),
                 member.getDepartment(),

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
@@ -12,7 +12,8 @@ public enum ErrorMessage {
     DUPLICATE_NICKNAME(400, "이미 사용중인 아이디입니다. 다른 아이디로 가입해주세요."),
     _NOT_MATCHED_VERIFIED_NUMBER(400, "인증 번호가 일치하지 않습니다."),
     _EXPIRED_NUMBER(401, "인증번호의 만료시간이 지났습니다."),
-    _NOT_MATCHED_PASSWORD(400, "비밀번호가 일치하지 않습니다.");
+    _NOT_MATCHED_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
+    NOT_MANAGER(400, "MANAGER이 아닙니다.");
 
     final int code;
     final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/NotManagerAccessException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/NotManagerAccessException.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.member.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.member.exception.ErrorMessage.NOT_MANAGER;
+
+public class NotManagerAccessException extends BaseErrorException {
+    public NotManagerAccessException() {
+        super(NOT_MANAGER.getCode(), NOT_MANAGER.getMessage());
+
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/project/controller/ProjectController.java
@@ -31,7 +31,7 @@ public class ProjectController {
                                                                  @RequestParam(defaultValue = "ALL", name = "generation") String generation,
                                                                  @RequestParam(defaultValue = "ALL", name = "field") String field) {
         Page<ProjectResponseDto> projects = projectService.getProjects(generation, field, pageable);
-        return new SuccessResponse<>(projects);
+        return new SuccessResponse<>(projects, SuccessMessage.PROJECT_READ.getMessage());
     }
 
     @PutMapping("/manager/project/{projectId}")


### PR DESCRIPTION
## ➕ 연관된 이슈
> #43
> Close #43

## 📑 작업 내용
> - SuccessMessage 추가
> - ErrorMessage 추가
> - deleteManager 메서드 구현
> - 일반 회원 및 다른 운영진이 탈퇴를 처리하지 못하도록 예외 처리
> - ADMIN 권한만 탈퇴 기능 처리할 수 있도록 구현
## ✂️ 스크린샷 (선택)


## 💭 리뷰 요구사항 (선택)
