### PR TITLE
[Feat] 토큰 저장 위치 변경

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -2,31 +2,30 @@ package com.tave.tavewebsite.domain.member.controller;
 
 import com.tave.tavewebsite.domain.member.dto.response.AuthorizedManagerResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
-import com.tave.tavewebsite.domain.member.service.MemberService;
+import com.tave.tavewebsite.domain.member.service.AdminService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/v1/admin")
 @RequiredArgsConstructor
 public class AdminController {
 
-    private final MemberService memberService;
+    private final AdminService adminService;
 
     @GetMapping("/unauthorized")
     public SuccessResponse<List<UnauthorizedManagerResponseDto>> getUnauthorizedManager() {
-        List<UnauthorizedManagerResponseDto> response = memberService.getUnauthorizedManager();
+        List<UnauthorizedManagerResponseDto> response = adminService.getUnauthorizedManager();
         return new SuccessResponse<>(response);
     }
 
     @GetMapping("/authorized")
     public SuccessResponse<List<AuthorizedManagerResponseDto>> getAuthorizedAdmins() {
-        List<AuthorizedManagerResponseDto> response = memberService.getAuthorizedAdmins();
+        List<AuthorizedManagerResponseDto> response = adminService.getAuthorizedAdmins();
         return new SuccessResponse<>(response);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -47,7 +47,7 @@ public class AuthController {
     public SuccessResponse<RefreshResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto requestDto,
                                                             @CookieValue("refreshToken") String refreshToken,
                                                             HttpServletResponse response) {
-        return new SuccessResponse<>(authService.refreshToken(requestDto, refreshToken, response));
+        return new SuccessResponse<>(authService.reissueToken(requestDto, refreshToken, response));
     }
 
     @GetMapping("/signout")

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -3,13 +3,16 @@ package com.tave.tavewebsite.domain.member.controller;
 import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
+import com.tave.tavewebsite.domain.member.dto.response.RefreshResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
+import com.tave.tavewebsite.domain.member.service.AuthService;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
-import com.tave.tavewebsite.global.security.entity.JwtToken;
 import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final MemberService memberService;
+    private final AuthService authService;
 
     @PostMapping("/signup")
     public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
@@ -33,20 +37,22 @@ public class AuthController {
     }
 
     @PostMapping("/signin")
-    public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto) {
-        SignInResponseDto signInResponseDto = memberService.signIn(requestDto);
+    public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto,
+                                                     HttpServletResponse response) {
+        SignInResponseDto signInResponseDto = authService.signIn(requestDto, response);
         return new SuccessResponse<>(signInResponseDto);
     }
 
     @PostMapping("/refresh")
-    public SuccessResponse<JwtToken> refreshToken(@RequestBody RefreshTokenRequestDto requestDto) {
-        JwtToken jwtToken = memberService.refreshToken(requestDto);
-        return new SuccessResponse<>(jwtToken);
+    public SuccessResponse<RefreshResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto requestDto,
+                                                            @CookieValue("refreshToken") String refreshToken,
+                                                            HttpServletResponse response) {
+        return new SuccessResponse<>(authService.refreshToken(requestDto, refreshToken, response));
     }
 
     @GetMapping("/signout")
     public SuccessResponse signOut(@RequestHeader("Authorization") String token) {
-        memberService.singOut(token);
+        authService.singOut(token);
         return SuccessResponse.ok();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.member.controller;
 import com.tave.tavewebsite.domain.member.dto.request.ResetPasswordReq;
 import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
 import com.tave.tavewebsite.domain.member.dto.response.CheckNickNameResponseDto;
+import com.tave.tavewebsite.domain.member.service.AdminService;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ManagerController {
 
     private final MemberService memberService;
+    private final AdminService adminService;
 
     @PostMapping("/normal/authenticate/email")
     public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto) {
@@ -39,7 +41,7 @@ public class ManagerController {
 
     @GetMapping("/normal/upgrade/{memberId}")
     public SuccessResponse updateAuthentication(@PathVariable("memberId") String memberId) {
-        memberService.updateAuthentication(memberId);
+        adminService.updateAuthentication(memberId);
 
         return new SuccessResponse("update Success.");
     }

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/RefreshTokenRequestDto.java
@@ -1,7 +1,6 @@
 package com.tave.tavewebsite.domain.member.dto.request;
 
 public record RefreshTokenRequestDto(
-        String email,
-        String refreshToken
+        String email
 ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/RefreshResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/RefreshResponseDto.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.member.dto.response;
+
+import com.tave.tavewebsite.global.security.entity.JwtToken;
+
+public record RefreshResponseDto(
+        String grantType,
+        String accessToken
+) {
+    public static RefreshResponseDto from(JwtToken jwtToken) {
+        return new RefreshResponseDto(jwtToken.getGrantType(), jwtToken.getAccessToken());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
@@ -6,7 +6,8 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.global.security.entity.JwtToken;
 
 public record SignInResponseDto(
-        JwtToken token,
+        String grantType,
+        String accessToken,
         Long memberId,
         String email,
         String nickname,
@@ -17,7 +18,8 @@ public record SignInResponseDto(
         JobType job
 ) {
     public static SignInResponseDto from(JwtToken token, Member member) {
-        return new SignInResponseDto(token,
+        return new SignInResponseDto(token.getGrantType(),
+                token.getAccessToken(),
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
@@ -1,0 +1,42 @@
+package com.tave.tavewebsite.domain.member.service;
+
+import static com.tave.tavewebsite.domain.member.entity.RoleType.MANAGER;
+import static com.tave.tavewebsite.domain.member.entity.RoleType.UNAUTHORIZED_MANAGER;
+
+import com.tave.tavewebsite.domain.member.dto.response.AuthorizedManagerResponseDto;
+import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
+import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final MemberRepository memberRepository;
+
+    public void updateAuthentication(String memberId) {
+        Long id = Long.valueOf(memberId);
+        Member member = memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
+        member.updateRole();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AuthorizedManagerResponseDto> getAuthorizedAdmins() {
+        return memberRepository.findByRole(MANAGER).stream()
+                .map(AuthorizedManagerResponseDto::fromEntity)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<UnauthorizedManagerResponseDto> getUnauthorizedManager() {
+        return memberRepository.findByRole(UNAUTHORIZED_MANAGER).stream()
+                .map(UnauthorizedManagerResponseDto::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -1,0 +1,70 @@
+package com.tave.tavewebsite.domain.member.service;
+
+import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
+import com.tave.tavewebsite.domain.member.dto.response.RefreshResponseDto;
+import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
+import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
+import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
+import com.tave.tavewebsite.global.redis.utils.RedisUtil;
+import com.tave.tavewebsite.global.security.entity.JwtToken;
+import com.tave.tavewebsite.global.security.exception.JwtValidException.NotMatchRefreshTokenException;
+import com.tave.tavewebsite.global.security.utils.CookieUtil;
+import com.tave.tavewebsite.global.security.utils.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
+
+    private static final int REFRESH_TOKEN_MAX_AGE = 60 * 24 * 3;
+    private static final int ACCESS_TOKEN_MAX_AGE = 30;
+
+    public SignInResponseDto signIn(SignUpRequestDto requestDto, HttpServletResponse response) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                requestDto.email(),
+                requestDto.password());
+        authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        JwtToken jwtToken = generateToken(requestDto.email());
+        CookieUtil.setCookie(response, "refreshToken", jwtToken.getRefreshToken());
+
+        return SignInResponseDto.from(generateToken(requestDto.email()),
+                memberRepository.findByEmail(requestDto.email()).get());
+
+    }
+
+    public void singOut(String accessToken) {
+        redisUtil.setBlackList(accessToken, "ban accessToken", ACCESS_TOKEN_MAX_AGE);
+    }
+
+    public RefreshResponseDto refreshToken(RefreshTokenRequestDto requestDto, String refreshToken,
+                                           HttpServletResponse response) {
+        Object refreshTokenByRedis = redisUtil.get(requestDto.email());
+        if (!refreshTokenByRedis.equals(refreshToken)) {
+            throw new NotMatchRefreshTokenException();
+        }
+
+        JwtToken jwtToken = generateToken(requestDto.email());
+        CookieUtil.setCookie(response, "refreshToken", jwtToken.getRefreshToken());
+        return RefreshResponseDto.from(jwtToken);
+    }
+
+    private JwtToken generateToken(String email) {
+        JwtToken jwtToken = jwtTokenProvider.generateToken(
+                memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new));
+        redisUtil.set(email, jwtToken.getRefreshToken(), REFRESH_TOKEN_MAX_AGE);
+
+        return jwtToken;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
         redisUtil.setBlackList(accessToken, "ban accessToken", ACCESS_TOKEN_MAX_AGE);
     }
 
-    public RefreshResponseDto refreshToken(RefreshTokenRequestDto requestDto, String refreshToken,
+    public RefreshResponseDto reissueToken(RefreshTokenRequestDto requestDto, String refreshToken,
                                            HttpServletResponse response) {
         Object refreshTokenByRedis = redisUtil.get(requestDto.email());
         if (!refreshTokenByRedis.equals(refreshToken)) {

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -1,28 +1,20 @@
 package com.tave.tavewebsite.domain.member.service;
 
-import static com.amazonaws.services.ec2.model.PrincipalType.Role;
-import static com.tave.tavewebsite.domain.member.entity.RoleType.MANAGER;
-import static com.tave.tavewebsite.domain.member.entity.RoleType.UNAUTHORIZED_MANAGER;
-
-import com.tave.tavewebsite.domain.member.dto.request.*;
-import com.tave.tavewebsite.domain.member.dto.response.AuthorizedManagerResponseDto;
-import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
-import com.tave.tavewebsite.domain.member.dto.response.UnauthorizedManagerResponseDto;
+import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.ResetPasswordReq;
+import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
 import com.tave.tavewebsite.domain.member.entity.Member;
-import com.tave.tavewebsite.domain.member.exception.*;
+import com.tave.tavewebsite.domain.member.exception.DuplicateEmailException;
+import com.tave.tavewebsite.domain.member.exception.DuplicateNicknameException;
+import com.tave.tavewebsite.domain.member.exception.ExpiredNumberException;
+import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
+import com.tave.tavewebsite.domain.member.exception.NotMatchedNumberException;
+import com.tave.tavewebsite.domain.member.exception.NotMatchedPassword;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
 import com.tave.tavewebsite.global.mail.service.MailService;
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
-import com.tave.tavewebsite.global.security.entity.JwtToken;
-import com.tave.tavewebsite.global.security.exception.JwtValidException.NotMatchRefreshTokenException;
-import com.tave.tavewebsite.global.security.utils.JwtTokenProvider;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,8 +26,6 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MailService mailService;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
 
@@ -48,46 +38,40 @@ public class MemberService {
         return mailService.sendManagerRegisterMessage(saveMember.getEmail());
     }
 
-    @Transactional(readOnly = true)
-    public List<UnauthorizedManagerResponseDto> getUnauthorizedManager() {
-        return memberRepository.findByRole(UNAUTHORIZED_MANAGER).stream()
-                .map(UnauthorizedManagerResponseDto::fromEntity)
-                .toList();
-    }
-
-    public SignInResponseDto signIn(SignUpRequestDto requestDto) {
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
-                requestDto.email(),
-                requestDto.password());
-        authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-        return SignInResponseDto.from(generateToken(requestDto.email()),
-                memberRepository.findByEmail(requestDto.email()).get());
-
-    }
-
-    public void singOut(String accessToken) {
-        redisUtil.setBlackList(accessToken, "ban accessToken", 30);
-    }
-
-    public JwtToken refreshToken(RefreshTokenRequestDto requestDto) {
-        Object refreshToken = redisUtil.get(requestDto.email());
-        if (!refreshToken.equals(requestDto.refreshToken())) {
-            throw new NotMatchRefreshTokenException();
-        }
-        return generateToken(requestDto.email());
-    }
-
     public void deleteMember(long id) {
         memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
         memberRepository.deleteById(id);
     }
 
-    private void validateEmail(String email) {
-        memberRepository.findByEmail(email).ifPresent(
-                member -> {
-                    throw new DuplicateEmailException();
-                }
-        );
+    public void sendMessage(ValidateEmailReq req) {
+        memberRepository.findByNickname(req.nickname()).orElseThrow(NotFoundMemberException::new);
+        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
+
+        mailService.sendAuthenticationCode(req.email());
+    }
+
+    public void verityNumber(ValidateEmailReq req) {
+        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
+        String validatedNumber = (String) redisUtil.get(req.email());
+
+        if (!req.number().equals(validatedNumber)) {
+            throw new NotMatchedNumberException();
+        } else if (redisUtil.checkExpired(req.email()) <= 0 || redisUtil.checkExpired(req.email()) == null) {
+            throw new ExpiredNumberException();
+        }
+
+        redisUtil.delete(req.email());
+    }
+
+    public void resetPassword(ResetPasswordReq req) {
+        Member member = memberRepository.findByNickname(req.nickname()).orElseThrow(NotFoundMemberException::new);
+
+        if (!req.password().equals(req.validatedPassword())) {
+            throw new NotMatchedPassword();
+        }
+
+        member.update(req.validatedPassword(), passwordEncoder);
+        memberRepository.save(member);
     }
 
     public void validateNickname(String nickname) {
@@ -98,57 +82,12 @@ public class MemberService {
         );
     }
 
-    private JwtToken generateToken(String email) {
-        JwtToken jwtToken = jwtTokenProvider.generateToken(
-                memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new));
-        redisUtil.set(email, jwtToken.getRefreshToken(), 120);
-
-        return jwtToken;
-    }
-
-    public void sendMessage(ValidateEmailReq req) {
-        memberRepository.findByNickname(req.nickname()).orElseThrow(NotFoundMemberException::new);
-        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
-
-        mailService.sendAuthenticationCode(req.email());
-    }
-
-    public void verityNumber(ValidateEmailReq req){
-        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
-        String validatedNumber = (String) redisUtil.get(req.email());
-
-        if(!req.number().equals(validatedNumber)){
-            throw new NotMatchedNumberException();
-        }
-        else if(redisUtil.checkExpired(req.email()) <= 0 || redisUtil.checkExpired(req.email()) == null){
-            throw new ExpiredNumberException();
-        }
-
-        redisUtil.delete(req.email());
-    }
-
-    public void resetPassword(ResetPasswordReq req){
-        Member member = memberRepository.findByNickname(req.nickname()).orElseThrow(NotFoundMemberException::new);
-
-        if(!req.password().equals(req.validatedPassword())){
-            throw new NotMatchedPassword();
-        }
-
-        member.update(req.validatedPassword(), passwordEncoder);
-        memberRepository.save(member);
-    }
-
-    public void updateAuthentication(String memberId){
-        Long id = Long.valueOf(memberId);
-        Member member = memberRepository.findById(id).orElseThrow(NotFoundMemberException::new);
-        member.updateRole();
-    }
-
-    @Transactional(readOnly = true)
-    public List<AuthorizedManagerResponseDto> getAuthorizedAdmins() {
-        return memberRepository.findByRole(MANAGER).stream()
-                .map(AuthorizedManagerResponseDto::fromEntity)
-                .toList();
+    private void validateEmail(String email) {
+        memberRepository.findByEmail(email).ifPresent(
+                member -> {
+                    throw new DuplicateEmailException();
+                }
+        );
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/config/Config.java
@@ -9,7 +9,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,10 +34,10 @@ public class Config {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
 
-        corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+        corsConfiguration.setAllowedOriginPatterns(List.of("http://localhost:3000", "http://localhost:8080"));
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"));
-        corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type", "X-XSRF-TOKEN"));
-        corsConfiguration.setExposedHeaders(List.of("X-XSRF-TOKEN"));
+        corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+        corsConfiguration.setExposedHeaders(List.of("Set-Cookie"));
         corsConfiguration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,8 +1,8 @@
 package com.tave.tavewebsite.global.security.exception;
 
-import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.CANNOT_USE_REFRESHTOKEN;
-import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.EXPIRED_JWT_TOKEN;
+import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.CANNOT_USE_REFRESH_TOKEN;
 import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.INVALID_JWT_TOKEN;
+import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.NEED_ACCESS_TOKEN_REFRESH;
 import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.SIGN_OUT_USER;
 import static com.tave.tavewebsite.global.security.exception.JwtErrorMessage.UNSUPPORTED_JWT_TOKEN;
 
@@ -26,18 +26,19 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         if (request.getAttribute("signOutException") != null) {
             setResponse(response, SIGN_OUT_USER.getErrorCode(), SIGN_OUT_USER.getMessage());
         } else if (request.getAttribute("cannotUseRefreshToken") != null) {
-            setResponse(response, CANNOT_USE_REFRESHTOKEN.getErrorCode(), CANNOT_USE_REFRESHTOKEN.getMessage());
+            setResponse(response, CANNOT_USE_REFRESH_TOKEN.getErrorCode(), CANNOT_USE_REFRESH_TOKEN.getMessage());
         } else if (request.getAttribute("invalidJwtToken") != null) {
             setResponse(response, INVALID_JWT_TOKEN.getErrorCode(), INVALID_JWT_TOKEN.getMessage());
         } else if (request.getAttribute("expiredJwtToken") != null) {
-            setResponse(response, EXPIRED_JWT_TOKEN.getErrorCode(), EXPIRED_JWT_TOKEN.getMessage());
+            setResponse(response, NEED_ACCESS_TOKEN_REFRESH.getErrorCode(), NEED_ACCESS_TOKEN_REFRESH.getMessage());
+        } else if (request.getAttribute("notExistAccessToken") != null) {
+            setResponse(response, NEED_ACCESS_TOKEN_REFRESH.getErrorCode(), NEED_ACCESS_TOKEN_REFRESH.getMessage());
         } else if (request.getAttribute("unsupportedJwtToken") != null) {
             setResponse(response, UNSUPPORTED_JWT_TOKEN.getErrorCode(), UNSUPPORTED_JWT_TOKEN.getMessage());
         } else {
             // 나머지 잘못된 요청에 대한 기본 예외 처리
             setResponse(response, 401, "잘못된 인증 요청입니다."); // 기본적으로 401 상태 코드와 에러 메시지 반환
         }
-
 
 
     }

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/JwtErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/JwtErrorMessage.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 public enum JwtErrorMessage {
 
     INVALID_JWT_TOKEN(401, "유효하지 않은 JWT 토큰 입니다."),
-    EXPIRED_JWT_TOKEN(401, "만료된 JWT 토큰입니다."),
-    CANNOT_USE_REFRESHTOKEN(400, "리프레쉬 토큰은 사용할 수 없습니다."),
+    NEED_ACCESS_TOKEN_REFRESH(401, "토큰 재발급이 필요합니다."),
+    CANNOT_USE_REFRESH_TOKEN(400, "리프레쉬 토큰은 사용할 수 없습니다."),
     UNSUPPORTED_JWT_TOKEN(401, "지원하지 않는 유형의 JWT 토큰입니다."),
-    NOT_MATCH_REFRESHTOKEN(400, "refreshToken의 값이 일치하지 않습니다."),
+    NOT_MATCH_REFRESH_TOKEN(400, "로그인이 필요한 서비스입니다."),
     SIGN_OUT_USER(400, "이미 로그아웃한 사용자 입니다."),
     CLAIMS_IS_EMPTY(401, "Claims 내부에 값이 들어있지 않습니다.");
 

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/JwtValidException.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/JwtValidException.java
@@ -12,7 +12,8 @@ public abstract class JwtValidException {
 
     public static class ExpiredTokenException extends BaseErrorException {
         public ExpiredTokenException() {
-            super(JwtErrorMessage.EXPIRED_JWT_TOKEN.getErrorCode(), JwtErrorMessage.INVALID_JWT_TOKEN.getMessage());
+            super(JwtErrorMessage.NEED_ACCESS_TOKEN_REFRESH.getErrorCode(),
+                    JwtErrorMessage.NEED_ACCESS_TOKEN_REFRESH.getMessage());
         }
     }
 
@@ -31,8 +32,8 @@ public abstract class JwtValidException {
 
     public static class NotMatchRefreshTokenException extends BaseErrorException {
         public NotMatchRefreshTokenException() {
-            super(JwtErrorMessage.NOT_MATCH_REFRESHTOKEN.getErrorCode(),
-                    JwtErrorMessage.NOT_MATCH_REFRESHTOKEN.getMessage());
+            super(JwtErrorMessage.NOT_MATCH_REFRESH_TOKEN.getErrorCode(),
+                    JwtErrorMessage.NOT_MATCH_REFRESH_TOKEN.getMessage());
         }
     }
 
@@ -45,8 +46,8 @@ public abstract class JwtValidException {
 
     public static class CannotUseRefreshToken extends BaseErrorException {
         public CannotUseRefreshToken() {
-            super(JwtErrorMessage.CANNOT_USE_REFRESHTOKEN.getErrorCode(),
-                    JwtErrorMessage.CANNOT_USE_REFRESHTOKEN.getMessage());
+            super(JwtErrorMessage.CANNOT_USE_REFRESH_TOKEN.getErrorCode(),
+                    JwtErrorMessage.CANNOT_USE_REFRESH_TOKEN.getMessage());
         }
     }
 }

--- a/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throw new SignOutUserException();
         }
 
+        // 3. 새로고침 시 메모리에 저장된 액세스 토큰이 사라졌을 시 발생시키는 에러
         if (token == null) {
             request.setAttribute("notExistAccessToken", 401);
         }

--- a/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
@@ -32,7 +32,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throw new SignOutUserException();
         }
 
-        // 3. validateToken으로 토큰 유효성 검사
+        if (token == null) {
+            request.setAttribute("notExistAccessToken", 401);
+        }
+
+        // 4. validateToken으로 토큰 유효성 검사
         if (token != null && jwtTokenProvider.validateToken(request, token)) {
             // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(request, token);

--- a/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.global.security.filter;
 
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
+import com.tave.tavewebsite.global.security.exception.JwtValidException.ExpiredTokenException;
 import com.tave.tavewebsite.global.security.exception.JwtValidException.SignOutUserException;
 import com.tave.tavewebsite.global.security.utils.JwtTokenProvider;
 import jakarta.servlet.FilterChain;
@@ -35,10 +36,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // 3. 새로고침 시 메모리에 저장된 액세스 토큰이 사라졌을 시 발생시키는 에러
         if (token == null) {
             request.setAttribute("notExistAccessToken", 401);
+            throw new ExpiredTokenException();
         }
 
         // 4. validateToken으로 토큰 유효성 검사
-        if (token != null && jwtTokenProvider.validateToken(request, token)) {
+        if (jwtTokenProvider.validateToken(request, token)) {
             // 토큰이 유효할 경우 토큰에서 Authentication 객체를 가지고 와서 SecurityContext에 저장
             Authentication authentication = jwtTokenProvider.getAuthentication(request, token);
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/tave/tavewebsite/global/security/utils/CookieUtil.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/utils/CookieUtil.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.global.security.utils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    private static final int MAX_AGE_OF_COOKIE = 3 * 24 * 60 * 60;
+
+    public static void setCookie(HttpServletResponse response, String name, String value) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .maxAge(MAX_AGE_OF_COOKIE)
+                .path("/")
+                .secure(false)
+                .httpOnly(true)
+                .sameSite("None")
+                .build();
+
+        response.setHeader("Set-Cookie", cookie.toString());
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #40 
> Close #40 

## 📑 작업 내용
> - 보안을 위해 리프레시 토큰을 쿠키에 설정하고, 액세스 토큰은 메모리에 저장하도록 변경했다.
> - 리프레시 토큰은 현재 Http Only 옵션이 true로 Secure 옵션이 false로 설정돼있다. Secure 옵션은 https 배포 이후 true로 변경할 예정이다.
> - 코드의 가독성을 위해 Admin 서비스와 Auth 서비스를 분리했다. 

## 💭 참고자료
> https://2junbeom.tistory.com/143
