### PR TITLE
[Fix] 로그아웃 로직 수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -51,8 +51,8 @@ public class AuthController {
     }
 
     @GetMapping("/signout")
-    public SuccessResponse signOut(@RequestHeader("Authorization") String token) {
-        authService.singOut(token);
+    public SuccessResponse signOut(@RequestHeader("Authorization") String token, HttpServletResponse response) {
+        authService.singOut(token, response);
         return SuccessResponse.ok();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -44,8 +44,9 @@ public class AuthService {
 
     }
 
-    public void singOut(String accessToken) {
-        redisUtil.setBlackList(accessToken, "ban accessToken", ACCESS_TOKEN_MAX_AGE);
+    public void singOut(String accessToken, HttpServletResponse response) {
+        redisUtil.set(accessToken, "ban accessToken", ACCESS_TOKEN_MAX_AGE);
+        CookieUtil.deleteCookie(response, "refreshToken");
     }
 
     public RefreshResponseDto reissueToken(RefreshTokenRequestDto requestDto, String refreshToken,

--- a/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/utils/RedisUtil.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 public class RedisUtil {
 
     private final RedisTemplate<String, String> redisTemplate;
-    private final RedisTemplate<String, String> redisBlackListTemplate;
 
     public void set(String key, String o, int minutes) {
         redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
@@ -26,22 +25,6 @@ public class RedisUtil {
 
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
-    }
-
-    public void setBlackList(String key, String o, int minutes) {
-        redisBlackListTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
-    }
-
-    public Object getBlackList(String key) {
-        return redisBlackListTemplate.opsForValue().get(key);
-    }
-
-    public boolean deleteBlackList(String key) {
-        return Boolean.TRUE.equals(redisBlackListTemplate.delete(key));
-    }
-
-    public boolean hasKeyBlackList(String key) {
-        return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
     }
 
     public Long checkExpired(String key) {

--- a/src/main/java/com/tave/tavewebsite/global/security/utils/CookieUtil.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/utils/CookieUtil.java
@@ -20,4 +20,16 @@ public class CookieUtil {
 
         response.setHeader("Set-Cookie", cookie.toString());
     }
+
+    public static void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, "value")
+                .maxAge(0)
+                .path("/")
+                .secure(false)
+                .httpOnly(true)
+                .sameSite("None")
+                .build();
+
+        response.setHeader("Set-Cookie", cookie.toString());
+    }
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #50 
> Close #50 

## 📑 작업 내용
> - 로그아웃 시 리프레시 토큰 쿠키를 삭제하는 로직 추가
> - 레디스 블랙 리스트 템플릿을 삭제하고, 하나의 템플릿으로 통합하였다.

## 💭 설명
> 레디스 블랙 리스트 템플릿은 오로지 로그아웃만을 위해 사용됩니다. 하지만 로그아웃만을 위해 레디스 서버를 하나 더 띄워서 블랙리스트 템플릿을 유지하는 것은 낭비가 너무 크다는 생각에 하나의 템플릿으로 통합 시켜 하나의 레디스 서버에서 로그아웃을 체크하도록 하였습니다.
