### PR TITLE
[feat] 대기 운영진 승인/거절

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -29,4 +29,10 @@ public class AdminController {
         return SuccessResponse.ok(SuccessMessage.MANAGER_DELETE.getMessage());
     }
 
+    @PostMapping("/{memberId}/approve")
+    public SuccessResponse approveManager(@PathVariable Long memberId) {
+        adminService.approveManager(memberId);
+        return SuccessResponse.ok(SuccessMessage.MANAGER_APPROVED.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -29,13 +29,13 @@ public class AdminController {
         return SuccessResponse.ok(SuccessMessage.MANAGER_DELETE.getMessage());
     }
 
-    @PostMapping("/{memberId}/approve")
+    @PatchMapping("/unauthorized-manager/{memberId}")
     public SuccessResponse approveManager(@PathVariable Long memberId) {
         adminService.approveManager(memberId);
         return SuccessResponse.ok(SuccessMessage.MANAGER_APPROVED.getMessage());
     }
 
-    @PostMapping("/{memberId}/reject")
+    @DeleteMapping("/unauthorized-manager/{memberId}")
     public SuccessResponse rejectManager(@PathVariable Long memberId) {
         adminService.rejectManager(memberId);
         return SuccessResponse.ok(SuccessMessage.MANAGER_REJECTED.getMessage());

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AdminController.java
@@ -35,4 +35,10 @@ public class AdminController {
         return SuccessResponse.ok(SuccessMessage.MANAGER_APPROVED.getMessage());
     }
 
+    @PostMapping("/{memberId}/reject")
+    public SuccessResponse rejectManager(@PathVariable Long memberId) {
+        adminService.rejectManager(memberId);
+        return SuccessResponse.ok(SuccessMessage.MANAGER_REJECTED.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/SuccessMessage.java
@@ -15,7 +15,10 @@ public enum SuccessMessage {
     SEND_AUTHENTICATION_CODE("인증번호 발송에 성공했습니다."),
     VERIFY_SUCCESS_MESSAGE("인증에 성공했습니다."),
     CAN_USE_NICKNAME("닉네임 사용 가능합니다."),
-    RESET_PASSWORD_MESSAGE("비밀번호가 재설정되었습니다.\n 다시 로그인해주세요.");
+    RESET_PASSWORD_MESSAGE("비밀번호가 재설정되었습니다.\n 다시 로그인해주세요."),
+
+    MANAGER_APPROVED("대기 운영진이 승인되었습니다."),
+    MANAGER_REJECTED("대기 운영진이 거절되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/ErrorMessage.java
@@ -14,7 +14,8 @@ public enum ErrorMessage {
     _EXPIRED_NUMBER(401, "인증번호의 만료시간이 지났습니다."),
     _NOT_MATCHED_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
     NOT_MANAGER(400, "MANAGER이 아닙니다."),
-    INVALID_STATUS_VALUE(400, "유효하지 않은 상태 값입니다.");
+    INVALID_STATUS_VALUE(400, "유효하지 않은 상태 값입니다."),
+    NOT_FOUND_UNAUTHORIZED_MANAGER(400, "대기 중인 운영진을 찾을 수 없습니다."),;
 
     final int code;
     final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/member/exception/NotFoundUnauthorizedManager.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/exception/NotFoundUnauthorizedManager.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.member.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.member.exception.ErrorMessage.NOT_FOUND_UNAUTHORIZED_MANAGER;
+
+public class NotFoundUnauthorizedManager extends BaseErrorException {
+    public NotFoundUnauthorizedManager() {
+        super(NOT_FOUND_UNAUTHORIZED_MANAGER.getCode(), NOT_FOUND_UNAUTHORIZED_MANAGER.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
@@ -72,18 +72,17 @@ public class AdminService {
 
     @Transactional
     public void approveManager(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(NotFoundMemberException::new);
-
-        if (member.getRole() != RoleType.UNAUTHORIZED_MANAGER) {
-            throw new NotFoundUnauthorizedManager();
-        }
-
-        member.updateRole(); // Role을 MANAGER로 변경
+        Member member = validateUnauthorizedManager(memberId);
+        member.updateRole();
     }
 
     @Transactional
     public void rejectManager(Long memberId) {
+        Member member = validateUnauthorizedManager(memberId);
+        memberRepository.delete(member);
+    }
+
+    private Member validateUnauthorizedManager(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
@@ -91,6 +90,7 @@ public class AdminService {
             throw new NotFoundUnauthorizedManager();
         }
 
-        memberRepository.deleteById(memberId);
+        return member;
     }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
@@ -6,6 +6,7 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.entity.RoleType;
 import com.tave.tavewebsite.domain.member.exception.InvalidStatusValueExcception;
 import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
+import com.tave.tavewebsite.domain.member.exception.NotFoundUnauthorizedManager;
 import com.tave.tavewebsite.domain.member.exception.NotManagerAccessException;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.global.success.SuccessResponse;
@@ -69,4 +70,14 @@ public class AdminService {
         memberRepository.deleteById(memberId);
     }
 
+    public void approveManager(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        if (member.getRole() != RoleType.UNAUTHORIZED_MANAGER) {
+            throw new NotFoundUnauthorizedManager();
+        }
+
+        member.updateRole(); // Role을 MANAGER로 변경
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
@@ -70,6 +70,7 @@ public class AdminService {
         memberRepository.deleteById(memberId);
     }
 
+    @Transactional
     public void approveManager(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AdminService.java
@@ -80,4 +80,16 @@ public class AdminService {
 
         member.updateRole(); // Role을 MANAGER로 변경
     }
+
+    @Transactional
+    public void rejectManager(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+
+        if (member.getRole() != RoleType.UNAUTHORIZED_MANAGER) {
+            throw new NotFoundUnauthorizedManager();
+        }
+
+        memberRepository.deleteById(memberId);
+    }
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #46
> Close #46

## 📑 작업 내용
> - 대기 중인 운영진 승인 성공하면 MANAGER로 Role 변경
> - 대기 중인 운영진 거절 성공하면 탈퇴 처리
> - 대기 중인 운영진 판별 예외 처리

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> - approveManager와 rejectManager 모두 데이터베이스에 읽기와 쓰기 작업을 수행합니다.
findById()로 데이터를 조회
approveManager는 updateRole()로 데이터를 수정
rejectManager는 deleteById()로 데이터를 삭제
> - 하나의 논리적인 단위로 실행되어야 하고 중간에 예외 발생 시 롤백 처리 되어야 하기 때문에 @Transactional을 사용했습니다.