### PR TITLE
[Feat] review 수정 사항

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.review.controller;
 
 
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
+import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
 import com.tave.tavewebsite.domain.review.dto.response.ReviewResponseDto;
 import com.tave.tavewebsite.domain.review.service.ReviewService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
@@ -32,8 +33,8 @@ public class ReviewController {
     }
 
     @GetMapping("/manager/review/{generation}")
-    public SuccessResponse<List<ReviewResponseDto>> getAllReviews(@PathVariable String generation) {
-        List<ReviewResponseDto> response = reviewService.findAllReviewsByGeneration(generation);
+    public SuccessResponse<List<ReviewIdResponseDto>> getAllReviews(@PathVariable String generation) {
+        List<ReviewIdResponseDto> response = reviewService.findAllReviewsByGeneration(generation);
 
         return new SuccessResponse<>(
                 response,

--- a/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
@@ -2,7 +2,7 @@ package com.tave.tavewebsite.domain.review.controller;
 
 
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
-import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
+import com.tave.tavewebsite.domain.review.dto.response.ReviewManagerResponseDto;
 import com.tave.tavewebsite.domain.review.dto.response.ReviewResponseDto;
 import com.tave.tavewebsite.domain.review.service.ReviewService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
@@ -33,8 +33,8 @@ public class ReviewController {
     }
 
     @GetMapping("/manager/review/{generation}")
-    public SuccessResponse<List<ReviewIdResponseDto>> getAllReviews(@PathVariable String generation) {
-        List<ReviewIdResponseDto> response = reviewService.findAllReviewsByGeneration(generation);
+    public SuccessResponse<List<ReviewManagerResponseDto>> getAllReviews(@PathVariable String generation) {
+        List<ReviewManagerResponseDto> response = reviewService.findAllReviewsByGeneration(generation);
 
         return new SuccessResponse<>(
                 response,

--- a/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
@@ -28,7 +28,7 @@ public class ReviewController {
         ReviewResponseDto response = reviewService.saveReview(requestDto);
         return new SuccessResponse<>(
                 response,
-                REVIEW_CREATE.getMessage(response.generation())
+                REVIEW_CREATE.getMessage()
         );
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/controller/ReviewController.java
@@ -37,7 +37,7 @@ public class ReviewController {
 
         return new SuccessResponse<>(
                 response,
-                REVIEW_GET_PUBLIC.getMessage(generation)
+                REVIEW_GET_MANAGER.getMessage(generation)
         );
     }
 
@@ -47,7 +47,7 @@ public class ReviewController {
         List<ReviewResponseDto> response = reviewService.findPublicReviews();
         return new SuccessResponse<>(
                 response,
-                REVIEW_GET_PRIVATE.getMessage()
+                REVIEW_GET_NORMAL.getMessage()
         );
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/review/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/controller/SuccessMessage.java
@@ -7,8 +7,8 @@ import lombok.Getter;
 public enum SuccessMessage {
 
     REVIEW_CREATE("후기를 생성합니다."),
-    REVIEW_GET_PUBLIC("공개 후기를 반환합니다."),
-    REVIEW_GET_PRIVATE("비공개 후기를 반환합니다."),
+    REVIEW_GET_NORMAL("공개 후기를 반환합니다."),
+    REVIEW_GET_MANAGER("모든 후기를 반환합니다."),
     REVIEW_UPDATE("후기를 수정했습니다."),
     REVIEW_DELETE("후기를 삭제했습니다.");
 

--- a/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewIdResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewIdResponseDto.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.review.dto.response;
+
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.Builder;
+
+@Builder
+public record ReviewIdResponseDto (
+        Long id,
+        String nickname,
+        String generation,
+        FieldType field,
+        String content,
+        boolean isPublic
+){
+}

--- a/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewManagerResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewManagerResponseDto.java
@@ -4,7 +4,7 @@ import com.tave.tavewebsite.global.common.FieldType;
 import lombok.Builder;
 
 @Builder
-public record ReviewIdResponseDto (
+public record ReviewManagerResponseDto(
         Long id,
         String nickname,
         String generation,

--- a/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewResponseDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 
 @Builder
 public record ReviewResponseDto(
-        Long id,
         String nickname,
         String generation,
         FieldType field,

--- a/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
@@ -29,7 +29,7 @@ public class ReviewMapper {
                 .build();
     }
 
-    public ReviewManagerResponseDto toReviewIdResponseDto(Review review) {
+    public ReviewManagerResponseDto toReviewManagerResponseDto(Review review) {
         return ReviewManagerResponseDto.builder()
                 .id(review.getId())
                 .nickname(review.getNickname())

--- a/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
@@ -1,7 +1,7 @@
 package com.tave.tavewebsite.domain.review.mapper;
 
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
-import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
+import com.tave.tavewebsite.domain.review.dto.response.ReviewManagerResponseDto;
 import com.tave.tavewebsite.domain.review.dto.response.ReviewResponseDto;
 import com.tave.tavewebsite.domain.review.entity.Review;
 import org.springframework.stereotype.Component;
@@ -29,8 +29,8 @@ public class ReviewMapper {
                 .build();
     }
 
-    public ReviewIdResponseDto toReviewIdResponseDto(Review review) {
-        return ReviewIdResponseDto.builder()
+    public ReviewManagerResponseDto toReviewIdResponseDto(Review review) {
+        return ReviewManagerResponseDto.builder()
                 .id(review.getId())
                 .nickname(review.getNickname())
                 .generation(review.getGeneration())

--- a/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.review.mapper;
 
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
+import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
 import com.tave.tavewebsite.domain.review.dto.response.ReviewResponseDto;
 import com.tave.tavewebsite.domain.review.entity.Review;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,16 @@ public class ReviewMapper {
 
     public ReviewResponseDto toReviewResponseDto(Review review) {
         return ReviewResponseDto.builder()
+                .nickname(review.getNickname())
+                .generation(review.getGeneration())
+                .field(review.getField())
+                .content(review.getContent())
+                .isPublic(review.isPublic())
+                .build();
+    }
+
+    public ReviewIdResponseDto toReviewIdResponseDto(Review review) {
+        return ReviewIdResponseDto.builder()
                 .id(review.getId())
                 .nickname(review.getNickname())
                 .generation(review.getGeneration())

--- a/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
@@ -1,7 +1,7 @@
 package com.tave.tavewebsite.domain.review.service;
 
 
-import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
+import com.tave.tavewebsite.domain.review.dto.response.ReviewManagerResponseDto;
 import com.tave.tavewebsite.domain.review.exception.ReviewNotFoundException;
 import com.tave.tavewebsite.domain.review.mapper.ReviewMapper;
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
@@ -40,7 +40,7 @@ public class ReviewService {
                 .toList();
     }
 
-    public List<ReviewIdResponseDto> findAllReviewsByGeneration(String generation) {
+    public List<ReviewManagerResponseDto> findAllReviewsByGeneration(String generation) {
         List<Review> reviews = reviewRepository.findByGeneration(generation);
 
         return reviews.stream()

--- a/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
@@ -44,7 +44,7 @@ public class ReviewService {
         List<Review> reviews = reviewRepository.findByGeneration(generation);
 
         return reviews.stream()
-                .map(reviewMapper::toReviewIdResponseDto)
+                .map(reviewMapper::toReviewManagerResponseDto)
                 .toList();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.review.service;
 
 
+import com.tave.tavewebsite.domain.review.dto.response.ReviewIdResponseDto;
 import com.tave.tavewebsite.domain.review.exception.ReviewNotFoundException;
 import com.tave.tavewebsite.domain.review.mapper.ReviewMapper;
 import com.tave.tavewebsite.domain.review.dto.request.ReviewRequestDto;
@@ -39,11 +40,11 @@ public class ReviewService {
                 .toList();
     }
 
-    public List<ReviewResponseDto> findAllReviewsByGeneration(String generation) {
+    public List<ReviewIdResponseDto> findAllReviewsByGeneration(String generation) {
         List<Review> reviews = reviewRepository.findByGeneration(generation);
 
         return reviews.stream()
-                .map(reviewMapper::toReviewResponseDto)
+                .map(reviewMapper::toReviewIdResponseDto)
                 .toList();
     }
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #53 
> Close #53 

## 📑 작업 내용
> - ReviewResponsetDto 필드 내용 수정
> - ReviewIdResponseDto 필드 추가
> - 리뷰 조회 API별 반환 메세지 수정
> - 리뷰 생성시 응답 메세지 "리뷰를 생성했습니다"로 수정

### ReviewResponseDto 필드 내용 수정 
리뷰 생성 후 응답에 id가 반환되지 않도록 ReviewResponseDto id 필드를 삭제했습니다.

### ReviewIdResponseDto 필드 추가
리뷰를 수정하기 위해서는 Review Id가 필요합니다.   
따라서 관리자가 조회하는 경우에는 Review Id를 반환할 수 있도록 ReviewManagerResponseDto를 추가했습니다.   
관리자가 조회한 페이지에서는 리뷰를 수정할 수 있어야 하기 때문입니다.   

### 리뷰 조회 API별 반환 메세지 수정
초기 Public과 Private 리뷰 조회 API로 설계를 해뒀습니다.   
중간에 비회원과 관리자가 조회할 수 있는 API로 설계를 변경했는데 응답 메세지는 변경되지 않았습니다.

#### 변경 후 응답 메세지
> - 비회원 리뷰 조회: "공개 후기를 반환합니다."
> - 관리자 리뷰 조회: "모든 후기를 반환합니다."


###  리뷰 생성시 응답 메세지 "리뷰를 생성했습니다"로 수정
기존 리뷰 생성 후 응답 메세지는 "14기 후기를 생성합니다.", "13기 후기를 생성합니다." 등 생성한 리뷰의 기수를 동적으로 반환했습니다.
굳이 리뷰 생성 후 응답 메세지에 기수별 정보를 담을 필요가 없고 상수로 통일성을 주는게 좋을 거 같다는 피드백을 반영합니다.   

수정된 응답 메세지는 "후기를 생성합니다." 입니다.

> - 수정 전: "14기 후기를 생성합니다.", "13기 후기를 생성합니다." 
> - 수정 후: "후기를 생성합니다." 


## ✂️ 스크린샷 (선택)
>
