### PR TITLE
[Feat] Hsitory 엔티티 수정 및 Resume 엔티티 생성

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/history/controller/HistorySuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/controller/HistorySuccessMessage.java
@@ -10,10 +10,6 @@ public enum HistorySuccessMessage {
 
     private final String message;
 
-    public String getMessage(String generation) {
-        return generation + " " + message;
-    }
-
     public String getMessage() {
         return message;
     }

--- a/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/controller/ManagerHistoryController.java
@@ -33,7 +33,7 @@ public class ManagerHistoryController {
     public SuccessResponse postHistory(@RequestBody @Valid HistoryRequestDto historyRequestDto) {
         historyService.save(historyRequestDto);
         return SuccessResponse.ok(
-                HistorySuccessMessage.POST_SUCCESS.getMessage(historyRequestDto.generation()));
+                HistorySuccessMessage.POST_SUCCESS.getMessage());
     }
 
     @PatchMapping("/{historyId}")
@@ -41,7 +41,7 @@ public class ManagerHistoryController {
                                          @RequestBody @Valid HistoryRequestDto historyRequestDto) {
         historyService.patch(id, historyRequestDto);
         return SuccessResponse.ok(
-                HistorySuccessMessage.UPDATE_SUCCESS.getMessage(historyRequestDto.generation()));
+                HistorySuccessMessage.UPDATE_SUCCESS.getMessage());
     }
 
     @DeleteMapping("/{historyId}")

--- a/src/main/java/com/tave/tavewebsite/domain/history/dto/request/HistoryRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/dto/request/HistoryRequestDto.java
@@ -9,6 +9,7 @@ public record HistoryRequestDto(
         String generation,
         @NotNull(message = "필수로 입력하셔야합니다.") @Size(min = 1, max = 500, message = "최대 500 글자까지 입력 가능합니다.")
         String description,
+        String additionalDescription,
         @NotNull(message = "필수로 입력하셔야합니다.")
         Boolean isPublic
 ) {
@@ -16,6 +17,7 @@ public record HistoryRequestDto(
         return History.builder()
                 .generation(this.generation)
                 .description(this.description)
+                .additionalDescription(this.additionalDescription)
                 .isPublic(this.isPublic)
                 .build();
     }

--- a/src/main/java/com/tave/tavewebsite/domain/history/dto/response/HistoryResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/dto/response/HistoryResponseDto.java
@@ -6,10 +6,11 @@ public record HistoryResponseDto(
         Long id,
         String generation,
         String description,
+        String additionalDescription,
         Boolean isPublic
 ) {
     public static HistoryResponseDto of(History history) {
         return new HistoryResponseDto(history.getId(), history.getGeneration(), history.getDescription(),
-                history.isPublic());
+                history.getAdditionalDescription(), history.isPublic());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
+++ b/src/main/java/com/tave/tavewebsite/domain/history/entity/History.java
@@ -37,20 +37,25 @@ public class History extends BaseEntity {
     @Column(length = 500, nullable = false)
     private String description;
 
+    @Size(min = 1, max = 255)
+    private String additionalDescription;
+
     @NotNull
     @Column(nullable = false)
     private boolean isPublic;
 
     @Builder
-    public History(String generation, String description, boolean isPublic) {
+    public History(String generation, String description, String additionalDescription, boolean isPublic) {
         this.generation = generation;
         this.description = description;
+        this.additionalDescription = additionalDescription;
         this.isPublic = isPublic;
     }
 
     public void patchHistory(HistoryRequestDto historyResponseDto) {
         generation = historyResponseDto.generation();
         description = historyResponseDto.description();
+        additionalDescription = historyResponseDto.additionalDescription();
         isPublic = historyResponseDto.isPublic();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
@@ -4,7 +4,9 @@ import static com.tave.tavewebsite.domain.member.entity.RoleType.MANAGER;
 import static com.tave.tavewebsite.domain.member.entity.RoleType.UNAUTHORIZED_MANAGER;
 
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,8 +14,12 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -43,7 +49,6 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private RoleType role;
 
-    @NotNull
     @Size(min = 2, max = 20)
     @Column(length = 20, nullable = false)
     private String nickname;
@@ -66,6 +71,18 @@ public class Member extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private JobType job;
+
+    @Size(min = 1, max = 13)
+    @Column(length = 13)
+    private String phoneNumber;
+
+    private LocalDate birthday;
+
+    @Enumerated(EnumType.STRING)
+    private Sex sex;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Resume> resumes = new ArrayList<>();
 
 
     @Builder
@@ -104,5 +121,9 @@ public class Member extends BaseEntity {
 
     public void updateRole() {
         this.role = MANAGER;
+    }
+
+    public void addResume(Resume resume) {
+        this.resumes.add(resume);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
@@ -1,0 +1,5 @@
+package com.tave.tavewebsite.domain.member.entity;
+
+public enum Sex {
+    MALE, FEMALE
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/LanguageLevel.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/LanguageLevel.java
@@ -1,0 +1,47 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LanguageLevel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(min = 1, max = 20)
+    @Column(length = 20, nullable = false)
+    private String language;
+
+    @Enumerated(EnumType.STRING)
+    private Level level;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Builder
+    public LanguageLevel(String language, Level level, Resume resume) {
+        this.language = language;
+        this.level = level;
+        this.resume = resume;
+        resume.getLanguageLevels().add(this);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Level.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Level.java
@@ -1,0 +1,5 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+public enum Level {
+    ONE, TWO, THREE, FOUR, FIVE
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Question.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Question.java
@@ -1,0 +1,46 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Size(min = 1, max = 300)
+    @Column(length = 300, nullable = false)
+    private String question;
+
+    @Size(min = 1, max = 1000)
+    @Column(length = 1000)
+    private String answer;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Builder
+    public Question(String question, String answer, Resume resume) {
+        this.question = question;
+        this.answer = answer;
+        this.resume = resume;
+        resume.getQuestions().add(this);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -1,0 +1,76 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+import com.tave.tavewebsite.domain.member.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resume {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+
+    @Size(min = 1, max = 20)
+    @Column(length = 20)
+    private String school;
+
+    @Size(max = 20)
+    @Column(length = 20)
+    private String major;
+
+    @Size(min = 1, max = 8)
+    @Column(length = 8)
+    private String field;
+
+    @ManyToOne
+    @JoinColumn(name = "memberId", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
+    private List<Question> questions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
+    private List<TimeSlot> timeSlots = new ArrayList<>();
+
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
+    private List<LanguageLevel> languageLevels = new ArrayList<>();
+
+    @Builder
+    public Resume(String school, String major, String field, Member member) {
+        this.school = school;
+        this.major = major;
+        this.field = field;
+        this.member = member;
+        member.addResume(this);
+    }
+
+    public void addQuestion(Question question) {
+        this.questions.add(question);
+    }
+
+    public void addTimeSlot(TimeSlot timeSlot) {
+        this.timeSlots.add(timeSlot);
+    }
+
+    public void addLanguageLevel(LanguageLevel languageLevel) {
+        this.languageLevels.add(languageLevel);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/TimeSlot.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/TimeSlot.java
@@ -1,0 +1,40 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TimeSlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDateTime time;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id", nullable = false)
+    private Resume resume;
+
+    @Builder
+    public TimeSlot(LocalDateTime time, Resume resume) {
+        this.time = time;
+        this.resume = resume;
+        resume.getTimeSlots().add(this);
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #55 
> Close #55 

## 📑 작업 내용
> - History 엔티티에 세부 설명 컬럼이 추가되었습니다.

> - 멤버 엔티티의 NickName 컬럼은 신규 회원이 도입되며, 필수가 아닌 것으로 바뀌었기에 데이터베이스 저장할 때에만 NotNull을 제거해주었습니다. 이후 핸드폰 번호, 생년월일, 성별 등의 칼럼을 추가해주었습니다.

> - 이력서 엔티티를 Resume로 추가하였습니다. 프로그래밍 별 실력과 질문, 면접 가능 시간 엔티티는 모두 일대다 관계로 연관관계 편의 메서드를 강제해주었습니다. 추가적으로 "다" 관계에 있는 엔티티 생성 시 외래키를 강제하기 위해 nullable : false 옵션을 추가하였습니다.

자료형은 모두 List로 선언하였습니다. 질문 엔티티를 HashMap이 아닌 List로 선택한 이유는, 질문을 개별 조회할 일이 없다고 판단했기 때문입니다. 프론트단에서 이력서를 조회할 때 페치 조인으로 모든 컬럼을 한 번에 조회하지 않으면 N+1 문제가 발생하기 때문에, 이력서를 조회할 때 무조건 페치 조인을 사용한다는 가정을 세웠고, 이에 따라 개별 조회를 할 일이 없다는 판단하에 HashMap 자료형 사용이 무의미 하다는 결론을 내렸습니다.