### PR TITLE
Feat/#57/이미지 확장자 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,11 @@ dependencies {
     implementation 'io.springfox:springfox-swagger2:2.9.2'
     implementation 'io.springfox:springfox-swagger-ui:2.9.2'
 
+    // Image Processing
+    implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
+    implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tave/tavewebsite/global/s3/exception/S3ErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/exception/S3ErrorException.java
@@ -15,4 +15,10 @@ public abstract class S3ErrorException {
             super(S3ErrorMessage.NOT_EXIST_NAME.getErrorCode(), S3ErrorMessage.NOT_EXIST_NAME.getMessage());
         }
     }
+
+    public static class S3ConvertFailException extends BaseErrorException {
+        public S3ConvertFailException() {
+            super(S3ErrorMessage.CONVERT_FAIL.getErrorCode(), S3ErrorMessage.CONVERT_FAIL.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/global/s3/exception/S3ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/exception/S3ErrorMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum S3ErrorMessage {
 
     UPLOAD_FAIL(400, "사진 업로드에 실패하였습니다."),
-    NOT_EXIST_NAME(404, "존재하지 않는 파일 이름입니다.");
+    NOT_EXIST_NAME(404, "존재하지 않는 파일 이름입니다."),
+    CONVERT_FAIL(500, "webp 확장자로 이미지 변환에 실패했습니다.");
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.webp.WebpWriter;
+import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3ConvertFailException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3NotExistNameException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3UploadFailException;
 import java.io.File;
@@ -76,7 +77,7 @@ public class S3Service {
                     .fromFile(tempFile) // .jpg or .png File 가져옴
                     .output(WebpWriter.DEFAULT, new File(fileName + ".webp")); // 손실 압축 설정, fileName.webp로 파일 생성
         } catch (Exception e) {
-            throw new S3UploadFailException();
+            throw new S3ConvertFailException();
         } finally {
             // 임시 파일 삭제
             if (tempFile != null && tempFile.exists()) {

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
@@ -34,8 +34,7 @@ public class S3Service {
 
     public URL uploadImages(MultipartFile file) {
         File convertFile = convertToWebp(file.getName(), file);
-        String key = convertFile.getName();
-        key = validateFileName(key);
+        String key = validateFileName(convertFile.getName());
         // MultipartFile에서 InputStream을 얻어 S3에 업로드합니다.
         try (InputStream inputStream = new FileInputStream(convertFile)) {
             ObjectMetadata metadata = setMetaData(convertFile);

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
@@ -4,13 +4,17 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sksamuel.scrimage.ImmutableImage;
+import com.sksamuel.scrimage.webp.WebpWriter;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3NotExistNameException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3UploadFailException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -28,16 +32,17 @@ public class S3Service {
     }
 
     public URL uploadImages(MultipartFile file) {
-        String key = file.getOriginalFilename();
+        File convertFile = convertToWebp(file.getName(), file);
+        String key = convertFile.getName();
         key = validateFileName(key);
         // MultipartFile에서 InputStream을 얻어 S3에 업로드합니다.
-        try (InputStream inputStream = file.getInputStream()) {
-            ObjectMetadata metadata = setMetaData(file);
-
+        try (InputStream inputStream = new FileInputStream(convertFile)) {
+            ObjectMetadata metadata = setMetaData(convertFile);
             // PutObjectRequest 생성 시 InputStream과 ContentType을 설정합니다.
             PutObjectRequest putRequest = new PutObjectRequest(bucketName, key, inputStream, metadata)
                     .withCannedAcl(CannedAccessControlList.PublicRead);
             s3Client.putObject(putRequest);
+            convertFile.delete();
             return getImageUrl(key);
         } catch (IOException e) {
             throw new S3UploadFailException();
@@ -60,10 +65,38 @@ public class S3Service {
         }
     }
 
-    private ObjectMetadata setMetaData(MultipartFile file) {
+    public File convertToWebp(String fileName, MultipartFile multipartFile) {
+        File tempFile = null;
+        try {
+            // MultipartFile을 File로 변환
+            tempFile = convertMultipartFileToFile(multipartFile);
+
+            // WebP로 변환
+            return ImmutableImage.loader() // 라이브러리 객체 생성
+                    .fromFile(tempFile) // .jpg or .png File 가져옴
+                    .output(WebpWriter.DEFAULT, new File(fileName + ".webp")); // 손실 압축 설정, fileName.webp로 파일 생성
+        } catch (Exception e) {
+            throw new S3UploadFailException();
+        } finally {
+            // 임시 파일 삭제
+            if (tempFile != null && tempFile.exists()) {
+                tempFile.delete();
+            }
+        }
+    }
+
+    private File convertMultipartFileToFile(MultipartFile multipartFile) throws IOException {
+        File file = new File(System.getProperty("java.io.tmpdir") + "/" + multipartFile.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(multipartFile.getBytes());
+        }
+        return file;
+    }
+
+    private ObjectMetadata setMetaData(File file) {
         ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(file.getSize());
-        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.length());
+        metadata.setContentType("image/webp");
 
         return metadata;
     }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #57 
> Close #57 

## 📑 작업 내용
> - 이미지 제공 속도를 최적화 하기 위해 컨트롤러를 통해 받은 이미지를 서비스단에서 webp 확장자로 변경 후 저장하는 로직을 추가하였다.
> - 이미지 저장 시 압축 방식은 손실 압축 방식을 선택하였다. 자세한 내용은 아래 링크에 정리해두었다.

https://2junbeom.tistory.com/162
