### PR TITLE
[Feat] Redis를 클라우드로 사용하도록 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/global/redis/config/RedisConfig.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/config/RedisConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
@@ -19,7 +20,11 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setPort(redisProperties.getPort());
+        config.setHostName(redisProperties.getHost());
+        config.setPassword(redisProperties.getPassword());
+        return new LettuceConnectionFactory(config);
     }
 
     @Bean

--- a/src/main/java/com/tave/tavewebsite/global/redis/entity/RedisProperties.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/entity/RedisProperties.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Component;
 public class RedisProperties {
     private int port;
     private String host;
+    private String password;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,9 +13,12 @@ spring:
         format_sql: true
   data:
     redis:
-      port: 6379
-      host: redis
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
       #host: 127.0.0.1
+      password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
 
   servlet:
     multipart:


### PR DESCRIPTION
## ➕ 연관된 이슈
> #65 
> Close #65 

## 📑 작업 내용
> - Redislabs를 이용하여 레디스를 글로벌 캐시로 전환하였습니다.

## ✂️ 스크린샷 (선택)
> Redislabs에서 Redis 서버 구축하기
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/56f568db-1898-45df-aaf5-baf5e99e8258" />

- 위의 그림에서 원하는 리전과 옵션을 선택한 후, 바로 아래에 제공되는 30MB를 선택하여 무료 버전을 사용할 수 있다.
- 이때 옵션에 따라 요금제가 적용될 수 있으니 주의해야한다.
- 그렇게 만들어진 데이터베이스에서 필요한 정보는 3가지이다. 엔드포인트, 포트, 비밀번호이다.

<img width="1240" alt="image" src="https://github.com/user-attachments/assets/f132dd2a-c4aa-4c83-8730-a266df8e0172" />
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/f466f4a2-e2e0-4814-aab4-d9caec857db8" />

- 제공되는 엔드포인트를 통해 Host와 Port를 알 수 있고, Security에 있는 비밀번호를 이용하면 해당 Redis Database로 접근할 수 있다!

이후 application.yml에서 해당 정보들을 기입하고 RedisConfig에 적용하면 글로벌 캐시를 사용할 수 있다!
<img width="360" alt="image" src="https://github.com/user-attachments/assets/f74eb6b4-0dde-42a6-8f46-19d9e1017277" />


## 참고자료
[Redis를 클라우드로 사용하자](https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-Redis%EB%A5%BC-%ED%81%B4%EB%9D%BC%EC%9A%B0%EB%93%9C%EB%A1%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EC%9E%90-Redislabs)

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
