### PR TITLE
Fix/#76/분야 별 반환 문자열 변경

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/dto/response/ReviewResponseDto.java
@@ -9,7 +9,7 @@ public record ReviewResponseDto(
         String nickname,
         String generation,
         String companyName,
-        FieldType field,
+        String field,
         String content,
         boolean isPublic
 ) {

--- a/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/review/mapper/ReviewMapper.java
@@ -25,7 +25,7 @@ public class ReviewMapper {
                 .nickname(review.getNickname())
                 .generation(review.getGeneration())
                 .companyName(review.getCompanyName())
-                .field(review.getField())
+                .field(review.getField().getMessage())
                 .content(review.getContent())
                 .isPublic(review.isPublic())
                 .build();

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -1,10 +1,17 @@
 package com.tave.tavewebsite.global.common;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum FieldType {
-    DEEPLEARNING,
-    DATAANALYSIS,
-    FRONTEND,
-    BACKEND,
-    ADVANCED,       // 심화
-    COLLABORATIVE   // 연합
+    DEEPLEARNING("Deep Learning"),
+    DATAANALYSIS("Data Analysis"),
+    FRONTEND("Frontend"),
+    BACKEND("Backend"),
+    ADVANCED("Advanced"),       // 심화
+    COLLABORATIVE("Collaborative");   // 연합
+
+    private final String message;
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #76
> Close #76 

## 📑 작업 내용
> - FieldType이 프론트 측 요청대로 반환되도록 수정
ex) 
- DATAANALYSIS -> Data Analysis
- DEEPLEARNING -> Deep Learning

ENUM 열거형을 변경하게 되면 RDB의 제약조건이 변경됩니다.
따라서 다음과 같이 요구사항을 반영하도록 했습니다.

1. 열거형에 해당하는 Message 값을 추가합니다.
2. ReviewResponseDto에서도 FieldType field 가 아닌 String field로 수정
3. Mapper에서 Review와 ReviewResponseDto를 매핑할 때, FieldType이 아니라 FieldType.getMessage()를 매핑하도록 수정

## ✂️ 스크린샷 (선택)
>
### 변경 후 Field 값
![image](https://github.com/user-attachments/assets/9523110b-38fd-4c78-8e9d-11bc700f7c88)


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
