### PR TITLE
Feat/#78/신규 지원 이메일 알림

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/EmailNotificationSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/EmailNotificationSuccessMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.emailnotification.controller;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum EmailNotificationSuccessMessage {
+    POST_SUCCESS("이메일 알림 신청에 성공했습니다.");
+
+    private final String message;
+
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/NormalEmailNotificationController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/NormalEmailNotificationController.java
@@ -1,0 +1,25 @@
+package com.tave.tavewebsite.domain.emailnotification.controller;
+
+import com.tave.tavewebsite.domain.emailnotification.dto.request.EmailNotificationRequeestDto;
+import com.tave.tavewebsite.domain.emailnotification.service.EmailNotificationService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/normal/notification")
+@RequiredArgsConstructor
+public class NormalEmailNotificationController {
+
+    private final EmailNotificationService emailNotificationService;
+
+    @PostMapping
+    public SuccessResponse postEmailNotification(@RequestBody @Valid EmailNotificationRequeestDto dto) {
+        emailNotificationService.save(dto);
+        return SuccessResponse.ok(EmailNotificationSuccessMessage.POST_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/dto/request/EmailNotificationRequeestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/dto/request/EmailNotificationRequeestDto.java
@@ -1,0 +1,16 @@
+package com.tave.tavewebsite.domain.emailnotification.dto.request;
+
+import com.tave.tavewebsite.domain.emailnotification.entity.EmailNotification;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record EmailNotificationRequeestDto(
+        @NotNull(message = "50자 이하로 입력해주세요.") @Size(min = 1, max = 50, message = "1~5 글자 사이로 입력해주세요.")
+        @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "유효한 이메일 주소를 입력하세요.")
+        String email
+) {
+    public EmailNotification toEmailNotification() {
+        return EmailNotification.builder().email(this.email).build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/dto/request/EmailNotificationRequeestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/dto/request/EmailNotificationRequeestDto.java
@@ -1,6 +1,5 @@
 package com.tave.tavewebsite.domain.emailnotification.dto.request;
 
-import com.tave.tavewebsite.domain.emailnotification.entity.EmailNotification;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -10,7 +9,4 @@ public record EmailNotificationRequeestDto(
         @Pattern(regexp = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$", message = "유효한 이메일 주소를 입력하세요.")
         String email
 ) {
-    public EmailNotification toEmailNotification() {
-        return EmailNotification.builder().email(this.email).build();
-    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailNotification.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailNotification.java
@@ -1,0 +1,39 @@
+package com.tave.tavewebsite.domain.emailnotification.entity;
+
+import com.tave.tavewebsite.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private EmailStatus status;
+
+    private Integer retryCount;
+
+    @Builder
+    public EmailNotification(String email) {
+        this.email = email;
+        this.status = EmailStatus.PENDING;
+        this.retryCount = 0;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailStatus.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailStatus.java
@@ -1,0 +1,5 @@
+package com.tave.tavewebsite.domain.emailnotification.entity;
+
+public enum EmailStatus {
+    PENDING, FAILED, SUCCESS;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/repository/EmailNotificationRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/repository/EmailNotificationRepository.java
@@ -1,0 +1,9 @@
+package com.tave.tavewebsite.domain.emailnotification.repository;
+
+import com.tave.tavewebsite.domain.emailnotification.entity.EmailNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailNotificationRepository extends JpaRepository<EmailNotification, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/service/EmailNotificationService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/service/EmailNotificationService.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.emailnotification.service;
 
 import com.tave.tavewebsite.domain.emailnotification.dto.request.EmailNotificationRequeestDto;
 import com.tave.tavewebsite.domain.emailnotification.repository.EmailNotificationRepository;
+import com.tave.tavewebsite.domain.emailnotification.util.EmailNotificationMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +13,7 @@ public class EmailNotificationService {
     private final EmailNotificationRepository emailNotificationRepository;
 
     public void save(EmailNotificationRequeestDto dto) {
-        emailNotificationRepository.save(dto.toEmailNotification());
+        emailNotificationRepository.save(EmailNotificationMapper.map(dto));
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/service/EmailNotificationService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/service/EmailNotificationService.java
@@ -1,0 +1,18 @@
+package com.tave.tavewebsite.domain.emailnotification.service;
+
+import com.tave.tavewebsite.domain.emailnotification.dto.request.EmailNotificationRequeestDto;
+import com.tave.tavewebsite.domain.emailnotification.repository.EmailNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailNotificationService {
+
+    private final EmailNotificationRepository emailNotificationRepository;
+
+    public void save(EmailNotificationRequeestDto dto) {
+        emailNotificationRepository.save(dto.toEmailNotification());
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/util/EmailNotificationMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/util/EmailNotificationMapper.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.emailnotification.util;
+
+import com.tave.tavewebsite.domain.emailnotification.dto.request.EmailNotificationRequeestDto;
+import com.tave.tavewebsite.domain.emailnotification.entity.EmailNotification;
+
+public class EmailNotificationMapper {
+
+    public static EmailNotification map(EmailNotificationRequeestDto emailNotificationRequeestDto) {
+        return EmailNotification.builder()
+                .email(emailNotificationRequeestDto.email())
+                .build();
+    }
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #78 
> Close #78 

## 📑 작업 내용
> - 이메일 알림 신청 엔티티 개발과 이메일을 저장하는 POST 기능을 추가했습니다.

이메일 알림 신청 엔티티의 상태는 이메일 신청 성공, 실패 여부를 판단합니다.
이를 기반으로 재시도를 구현할 것이며

재시도 최대 횟수를 제한하기 위해 재시도 컬럼을 추가했습니다.