### PR TITLE
[Fix] 이메일 인증에 불필요한 필드 삭제

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ValidateEmailReq.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ValidateEmailReq.java
@@ -1,7 +1,9 @@
 package com.tave.tavewebsite.domain.member.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record ValidateEmailReq(
-        String nickname,
+        @NotNull
         String email,
         String number
 ){

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -51,7 +51,6 @@ public class MemberService {
     }
 
     public void sendMessage(ValidateEmailReq req) {
-        memberRepository.findByNickname(req.nickname()).orElseThrow(NotFoundMemberException::new);
         memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
 
         mailService.sendAuthenticationCode(req.email());


### PR DESCRIPTION
## ➕ 연관된 이슈
> #84 
> Close #84 

## 📑 작업 내용
> - 이메일을 인증하는 과정에서 닉네임이 불필요하다는 의견을 수렴하여 nickname에 대한 로직을 삭제하였습니다.

## ✂️ 스크린샷 (선택)
<img width="246" alt="image" src="https://github.com/user-attachments/assets/3cef440d-390f-4c2a-990e-99dd47fdb9fc" />
<img width="711" alt="image" src="https://github.com/user-attachments/assets/5af42b4f-2e0c-46c3-a48c-5509bf0977cc" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
