### PR TITLE
[fix] 회원가입 및 비밀번호 재설정 API 통합

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -30,7 +30,7 @@ public class ManagerController {
 
     @PostMapping("/normal/authenticate/email")
     public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto,
-                                     @RequestParam(required = false, defaultValue = "false") String reset) {
+                                     @RequestParam(required = false, defaultValue = "false") Boolean reset) {
 
         memberService.sendMessage(requestDto, reset);
 

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -9,13 +9,7 @@ import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.tave.tavewebsite.domain.member.controller.MemberSuccessMessage.NORMAL_MEMBER_SIGNUP;
 
@@ -35,9 +29,10 @@ public class ManagerController {
     }
 
     @PostMapping("/normal/authenticate/email")
-    public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto) {
+    public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto,
+                                     @RequestParam(required = false, defaultValue = "false") String reset) {
 
-        memberService.sendMessage(requestDto);
+        memberService.sendMessage(requestDto, reset);
 
         return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -50,8 +50,8 @@ public class MemberService {
         memberRepository.deleteById(id);
     }
 
-    public void sendMessage(ValidateEmailReq req, String reset) {
-        if(reset.equals("false"))
+    public void sendMessage(ValidateEmailReq req, Boolean reset) {
+        if(reset.equals(Boolean.FALSE))
             validateEmail(req.email());
         else
             findIfEmailExists(req.email());
@@ -91,8 +91,8 @@ public class MemberService {
         );
     }
 
-    private void findIfEmailExists(String email) {
-        memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
+    private Member findIfEmailExists(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
     }
 
     private void validateEmail(String email) {

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -50,8 +50,11 @@ public class MemberService {
         memberRepository.deleteById(id);
     }
 
-    public void sendMessage(ValidateEmailReq req) {
-        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
+    public void sendMessage(ValidateEmailReq req, String reset) {
+        if(reset.equals("false"))
+            validateEmail(req.email());
+        else
+            findIfEmailExists(req.email());
 
         mailService.sendAuthenticationCode(req.email());
     }
@@ -86,6 +89,10 @@ public class MemberService {
                     throw new DuplicateNicknameException();
                 }
         );
+    }
+
+    private void findIfEmailExists(String email) {
+        memberRepository.findByEmail(email).orElseThrow(NotFoundMemberException::new);
     }
 
     private void validateEmail(String email) {


### PR DESCRIPTION
## ➕ 연관된 이슈
> #90 
> Close #90 

## 📑 작업 내용
> - 회원가입 및 비밀번호 재설정 시 필요한 이메일 인증 API를 하나로 통합하였습니다.

## ✂️ 스크린샷 (선택)
> - 회원가입과 비밀번호 재설정은 각각 이메일 인증이 필요합니다. 하지만 이때 이메일의 DB 내의 존재 여부에 따라 기능이 달라집니다.
> - RequestParam을 사용하여 reset에 대한 값이 "false" or 설정하지 않을 경우에는 회원가입 로직을 수행하고, 
> "true" or any value가 들어갈 경우에는 비밀번호 재설정에 대한 로직을 수행합니다.
<img width="835" alt="image" src="https://github.com/user-attachments/assets/0818ac55-261d-4f05-a12d-c866306f90aa" />
<img width="541" alt="image" src="https://github.com/user-attachments/assets/346e9780-5b18-4ddb-87b9-f06aab199f2c" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
