### PR TITLE
[Feat] 프로그래밍 실력 관련 crud 작업

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
@@ -23,7 +23,8 @@ public class ProgramingLanguageController {
 
     @GetMapping("/v1/normal/lan/{id}")
     public SuccessResponse<List<LanguageLevelResponseDto>> getLanguageLevels(@PathVariable("id") Long id) {
-        return new SuccessResponse<>(programingLanguageService.getLanguageLevel(id));
+        return new SuccessResponse<>(programingLanguageService.getLanguageLevel(id),
+                ProgramingLanguageSuccessMessage.READ_SUCCESS.getMessage());
     }
 
     @PatchMapping("/v1/normal/lan/{id}")

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
@@ -1,0 +1,35 @@
+package com.tave.tavewebsite.domain.programinglaunguage.controller;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.request.LanguageLevelRequestDto;
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.service.ProgramingLanguageService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class ProgramingLanguageController {
+
+    private final ProgramingLanguageService programingLanguageService;
+
+    @GetMapping("/v1/normal/lan/{id}")
+    public SuccessResponse<List<LanguageLevelResponseDto>> getLanguageLevels(@PathVariable("id") Long id) {
+        return new SuccessResponse<>(programingLanguageService.getLanguageLevel(id));
+    }
+
+    @PatchMapping("/v1/normal/lan/{id}")
+    public SuccessResponse patchLanguageLevels(@PathVariable("id") Long id,
+                                               @RequestBody @Valid List<LanguageLevelRequestDto> languageLevelRequestDtos) {
+        programingLanguageService.patchLanguageLevel(id, languageLevelRequestDtos);
+        return SuccessResponse.ok(ProgramingLanguageSuccessMessage.UPDATE_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
@@ -4,7 +4,8 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum ProgramingLanguageSuccessMessage {
-    UPDATE_SUCCESS("레벨 수정에 성공했습니다.");
+    UPDATE_SUCCESS("레벨 수정에 성공했습니다."),
+    READ_SUCCESS("레벨 조회에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.programinglaunguage.controller;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum ProgramingLanguageSuccessMessage {
+    UPDATE_SUCCESS("레벨 수정에 성공했습니다.");
+
+    private final String message;
+
+    public String getMessage() {
+        return message;
+    }
+}
+

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/LanguageLevelRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/LanguageLevelRequestDto.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.programinglaunguage.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record LanguageLevelRequestDto(
+        String language,
+        @Max(value = 5, message = "1 이상, 5 이하의 숫자만 가능합니다.")
+        @Min(value = 1, message = "1 이상, 5 이하의 숫자만 가능합니다.")
+        Integer level
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/response/LanguageLevelResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/response/LanguageLevelResponseDto.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.programinglaunguage.dto.response;
+
+public record LanguageLevelResponseDto(
+        String language,
+        Integer level
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/LanguageLevel.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/LanguageLevel.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -31,6 +33,8 @@ public class LanguageLevel {
 
     @NotNull
     @Column(nullable = false)
+    @Max(5)
+    @Min(0)
     private Integer level;
 
     @ManyToOne
@@ -43,5 +47,9 @@ public class LanguageLevel {
         this.level = 0;
         this.resume = resume;
         resume.getLanguageLevels().add(this);
+    }
+
+    public void patchLanguageLevel(Integer level) {
+        this.level = level;
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/LanguageLevel.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/LanguageLevel.java
@@ -1,9 +1,8 @@
-package com.tave.tavewebsite.domain.resume.entity;
+package com.tave.tavewebsite.domain.programinglaunguage.entity;
 
+import com.tave.tavewebsite.domain.resume.entity.Resume;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,17 +29,18 @@ public class LanguageLevel {
     @Column(length = 20, nullable = false)
     private String language;
 
-    @Enumerated(EnumType.STRING)
-    private Level level;
+    @NotNull
+    @Column(nullable = false)
+    private Integer level;
 
     @ManyToOne
     @JoinColumn(name = "resume_id", nullable = false)
     private Resume resume;
 
     @Builder
-    public LanguageLevel(String language, Level level, Resume resume) {
+    public LanguageLevel(String language, Resume resume) {
         this.language = language;
-        this.level = level;
+        this.level = 0;
         this.resume = resume;
         resume.getLanguageLevels().add(this);
     }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/ProgramingLanguage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/ProgramingLanguage.java
@@ -1,0 +1,41 @@
+package com.tave.tavewebsite.domain.programinglaunguage.entity;
+
+import com.tave.tavewebsite.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProgramingLanguage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @NotNull
+    @Column(nullable = false)
+    @Size(min = 1, max = 20)
+    private String language;
+
+    @NotNull
+    @Column(nullable = false)
+    @Size(min = 1, max = 8)
+    private String field;
+
+    @Builder
+    ProgramingLanguage(String language, String field) {
+        this.language = language;
+        this.field = field;
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/LanguageLevelRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/LanguageLevelRepository.java
@@ -1,0 +1,9 @@
+package com.tave.tavewebsite.domain.programinglaunguage.repository;
+
+import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LanguageLevelRepository extends JpaRepository<LanguageLevel, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/ProgramingLanguageRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/ProgramingLanguageRepository.java
@@ -1,0 +1,9 @@
+package com.tave.tavewebsite.domain.programinglaunguage.repository;
+
+import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProgramingLanguageRepository extends JpaRepository<ProgramingLanguage, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageService.java
@@ -1,0 +1,53 @@
+package com.tave.tavewebsite.domain.programinglaunguage.service;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.request.LanguageLevelRequestDto;
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProgramingLanguageService {
+
+    private final ResumeRepository resumeRepository;
+
+    public List<LanguageLevelResponseDto> getLanguageLevel(Long resumeId) {
+        Resume resume = resumeRepository.findResumeWithLanguageLevels(resumeId);
+
+        List<LanguageLevelResponseDto> languageLevelResponseDtos = new ArrayList<>();
+
+        for (LanguageLevel languageLevel : resume.getLanguageLevels()) {
+            languageLevelResponseDtos.add(LanguageLevelMapper.toLanguageLevelResponseDto(languageLevel));
+        }
+
+        return languageLevelResponseDtos;
+    }
+
+    @Transactional
+    public void patchLanguageLevel(Long id, List<LanguageLevelRequestDto> languageLevelRequestDtos) {
+        Resume resumeWithLanguageLevels = resumeRepository.findResumeWithLanguageLevels(id);
+
+        // 요청 데이터를 Map으로 변환 (language -> level)
+        Map<String, Integer> levelMap = languageLevelRequestDtos.stream()
+                .collect(Collectors.toMap(LanguageLevelRequestDto::language, LanguageLevelRequestDto::level));
+
+        // 기존 LanguageLevel 리스트에서 매칭되는 경우 업데이트
+        resumeWithLanguageLevels.getLanguageLevels().forEach(languageLevel -> {
+            Integer newLevel = levelMap.get(languageLevel.getLanguage());
+            if (newLevel != null) {
+                languageLevel.patchLanguageLevel(newLevel);
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.programinglaunguage.util;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+
+public class LanguageLevelMapper {
+
+    public static LanguageLevelResponseDto toLanguageLevelResponseDto(LanguageLevel languageLevel) {
+        return new LanguageLevelResponseDto(languageLevel.getLanguage(), languageLevel.getLevel());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Level.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Level.java
@@ -1,5 +1,0 @@
-package com.tave.tavewebsite.domain.resume.entity;
-
-public enum Level {
-    ONE, TWO, THREE, FOUR, FIVE
-}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.resume.entity;
 
 import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.resume.repository;
+
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
+    @Query("select r from Resume r join fetch r.languageLevels join fetch r.member where r.id = :id")
+    Resume findResumeWithLanguageLevels(@Param("id") Long id);
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #89 
> Close #89 

## 📑 작업 내용
> - 초기 이력서 생성시 프로그래밍 언어를 모두 0으로 초기화 하여 지원분야에 맞는 프로그래밍 언어 객체를 생성하여 저장합니다.
> - 이후 프론트엔드에서 프로그래밍 언어 요청 시 초기화 시킨 객체를 반환합니다.
> - 프론트엔드에서 사용자가 수정한 프로그래밍 언어 별 실력을 리스트로 받으면 해당 리스트에 맞춰 객체를 수정합니다.

## ✂️ 스크린샷 (선택)
> 수정의 예시입니다.
<img width="406" alt="image" src="https://github.com/user-attachments/assets/52468a8c-6e72-4d45-b350-e782ac0acc84" />

> 조회의 예시입니다.
<img width="325" alt="image" src="https://github.com/user-attachments/assets/3b7efd61-e35d-4323-bc5b-b6bd3ed6a9a6" />



## 💭 리뷰 요구사항 (선택)
> 일대다 관계로 인한 쿼리 수의 증가로 fetch join을 적용하였습니다.
https://2junbeom.tistory.com/193

## 추후 필요한 작업 🧐
> 이력서 엔티티 생성 로직이 완성되면 해당 로직에 프로그래밍 언어를 0으로 초기화 하여 객체를 생성시키는 로직 추가
> 이력서 엔티티 조회 시 엔티티 조회에 실패한다면 던질 에러 코드 추가
