### PR TITLE
[Feat] 면접 기능 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotReqDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotReqDto.java
@@ -1,0 +1,6 @@
+package com.tave.tavewebsite.domain.resume.dto.timeslot;
+
+public record TimeSlotReqDto(
+        String time
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotResDto.java
@@ -1,4 +1,13 @@
 package com.tave.tavewebsite.domain.resume.dto.timeslot;
 
-public record TimeSlotResDto() {
+import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
+
+import java.time.LocalDateTime;
+
+public record TimeSlotResDto(
+        LocalDateTime time
+) {
+    public static TimeSlotResDto from(TimeSlot timeSlot) {
+        return new TimeSlotResDto(timeSlot.getTime());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/timeslot/TimeSlotResDto.java
@@ -1,0 +1,4 @@
+package com.tave.tavewebsite.domain.resume.dto.timeslot;
+
+public record TimeSlotResDto() {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/TimeSlot.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/TimeSlot.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.resume.entity;
 
+import com.tave.tavewebsite.domain.resume.exception.NotValidTimeException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,5 +39,22 @@ public class TimeSlot {
         this.time = time;
         this.resume = resume;
         resume.getTimeSlots().add(this);
+    }
+
+    public static TimeSlot of(String time, Resume resume) {
+        return TimeSlot.builder().
+                time(getTime(time)).
+                resume(resume).
+                build();
+    }
+
+    private static LocalDateTime getTime(String time) {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
+
+            return LocalDateTime.parse(time, formatter);
+        } catch (Exception e) {
+            throw new NotValidTimeException();
+        }
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorMessage {
 
+    UNAUTHORIZED_RESUME(403, "해당 이력서를 수정할 권한이 없습니다."),
     NOT_VALID_TIME(400, "올바르지 않은 형식의 시간대입니다."),
     NOT_FOUND_RESUME(404, "해당 이력서가 존재하지 않습니다.");
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    NOT_VALID_TIME(400, "올바르지 않은 형식의 시간대입니다."),
+    NOT_FOUND_RESUME(404, "해당 이력서가 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/NotValidTimeException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/NotValidTimeException.java
@@ -2,7 +2,6 @@ package com.tave.tavewebsite.domain.resume.exception;
 
 import com.tave.tavewebsite.global.exception.BaseErrorException;
 
-import static com.tave.tavewebsite.domain.project.exception.ErrorMessage.PROJECT_NOT_FOUND;
 import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.NOT_VALID_TIME;
 
 public class NotValidTimeException extends BaseErrorException {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/NotValidTimeException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/NotValidTimeException.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.project.exception.ErrorMessage.PROJECT_NOT_FOUND;
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.NOT_VALID_TIME;
+
+public class NotValidTimeException extends BaseErrorException {
+    public NotValidTimeException() {
+        super(NOT_VALID_TIME.getCode(), NOT_VALID_TIME.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ResumeNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ResumeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.NOT_FOUND_RESUME;
+
+public class ResumeNotFoundException extends BaseErrorException {
+    public ResumeNotFoundException() {
+        super(NOT_FOUND_RESUME.getCode(), NOT_FOUND_RESUME.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/UnauthoirzedResumeException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/UnauthoirzedResumeException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.UNAUTHORIZED_RESUME;
+
+public class UnauthoirzedResumeException extends BaseErrorException {
+    public UnauthoirzedResumeException() {
+        super(UNAUTHORIZED_RESUME.getCode(), UNAUTHORIZED_RESUME.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/UnauthorizedResumeException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/UnauthorizedResumeException.java
@@ -4,8 +4,8 @@ import com.tave.tavewebsite.global.exception.BaseErrorException;
 
 import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.UNAUTHORIZED_RESUME;
 
-public class UnauthoirzedResumeException extends BaseErrorException {
-    public UnauthoirzedResumeException() {
+public class UnauthorizedResumeException extends BaseErrorException {
+    public UnauthorizedResumeException() {
         super(UNAUTHORIZED_RESUME.getCode(), UNAUTHORIZED_RESUME.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.resume.repository;
+
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResumeRepository extends JpaRepository<Resume, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
     Optional<Resume> findByMember(Member member);
+
     @Query("select r from Resume r join fetch r.languageLevels join fetch r.member where r.id = :id")
     Resume findResumeWithLanguageLevels(@Param("id") Long id);
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -1,7 +1,12 @@
 package com.tave.tavewebsite.domain.resume.repository;
 
+import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
+
+    Optional<Resume> findByMember(Member member);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -5,7 +5,6 @@ import com.tave.tavewebsite.domain.resume.entity.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
@@ -3,5 +3,9 @@ package com.tave.tavewebsite.domain.resume.repository;
 import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+
+    List<TimeSlot> findAllByResumeId(Long resumeId);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
 
     List<TimeSlot> findAllByResumeId(Long resumeId);
+
+    void deleteAllByResumeId(Long resumeId);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/TimeSlotRepository.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.resume.repository;
+
+import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotService.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.resume.service;
 
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotReqDto;
 import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotResDto;
 import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
 
@@ -7,7 +8,7 @@ import java.util.List;
 
 public interface TimeSlotService {
 
-    void createTimeSlot(TimeSlot timeSlot);
-    void updateTimeSlot(TimeSlot timeSlot);
-    List<TimeSlotResDto> getTimeSlots(String timeSlotId);
+    void createTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlots);
+    void updateTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlot);
+    List<TimeSlotResDto> getTimeSlots(Long resumeId);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotService.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.resume.service;
+
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotResDto;
+import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
+
+import java.util.List;
+
+public interface TimeSlotService {
+
+    void createTimeSlot(TimeSlot timeSlot);
+    void updateTimeSlot(TimeSlot timeSlot);
+    List<TimeSlotResDto> getTimeSlots(String timeSlotId);
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -6,7 +6,7 @@ import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotResDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
-import com.tave.tavewebsite.domain.resume.exception.UnauthoirzedResumeException;
+import com.tave.tavewebsite.domain.resume.exception.UnauthorizedResumeException;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import com.tave.tavewebsite.domain.resume.repository.TimeSlotRepository;
 import com.tave.tavewebsite.global.security.utils.SecurityUtils;
@@ -58,7 +58,7 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     private void findIfResumeMine(Member currentMember, Resume resume) {
         Resume resumeByMember = resumeRepository.findByMember(currentMember).orElseThrow(ResumeNotFoundException::new);
         if(!resumeByMember.equals(resume)) {
-            throw new UnauthoirzedResumeException();
+            throw new UnauthorizedResumeException();
         }
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -32,22 +32,18 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     public void createTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlots) {
         Resume resume = findIfResumeExists(resumeId);
 
-        timeSlots.forEach(timeSlotReqDto -> {
-            TimeSlot timeSlot = TimeSlot.of(timeSlotReqDto.time(), resume);
-            timeSlotRepository.save(timeSlot);
-        });
+        saveTimeSlot(timeSlots, resume);
     }
 
+    @Transactional
     @Override
     public void updateTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlots) {
         Member currentMember = getCurrentMember();
         Resume resume = findIfResumeExists(resumeId);
         findIfResumeMine(currentMember, resume);
 
-//        timeSlots.forEach(timeSlotReqDto -> {
-//            TimeSlot timeSlot = timeSlotRepository.
-//            timeSlotRepository.save(timeSlot);
-//        })
+        timeSlotRepository.deleteAllByResumeId(resumeId);
+        saveTimeSlot(timeSlots, resume);
     }
 
     @Override
@@ -68,5 +64,12 @@ public class TimeSlotServiceImpl implements TimeSlotService {
 
     private Resume findIfResumeExists(Long resumeId) {
         return resumeRepository.findById(resumeId).orElseThrow(ResumeNotFoundException::new);
+    }
+
+    private void saveTimeSlot(List<TimeSlotReqDto> timeSlots, Resume resume) {
+        timeSlots.forEach(timeSlotReqDto -> {
+            TimeSlot timeSlot = TimeSlot.of(timeSlotReqDto.time(), resume);
+            timeSlotRepository.save(timeSlot);
+        });
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -32,14 +32,20 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     }
 
     @Override
-    public void updateTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlot) {
-
+    public void updateTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlots) {
+        // 이력서가 사용자의 소유인지 확인
+        Resume resume = findIfResumeExists(resumeId);
     }
 
     @Override
     public List<TimeSlotResDto> getTimeSlots(Long resumeId) {
-        return List.of();
+        findIfResumeExists(resumeId);
+        List<TimeSlot> timeSlots = timeSlotRepository.findAllByResumeId(resumeId);
+
+
+        return timeSlots.stream().map(TimeSlotResDto::from).toList();
     }
+
 
     private Resume findIfResumeExists(Long resumeId) {
         return resumeRepository.findById(resumeId).orElseThrow(ResumeNotFoundException::new);

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -67,9 +67,14 @@ public class TimeSlotServiceImpl implements TimeSlotService {
     }
 
     private void saveTimeSlot(List<TimeSlotReqDto> timeSlots, Resume resume) {
-        timeSlots.forEach(timeSlotReqDto -> {
-            TimeSlot timeSlot = TimeSlot.of(timeSlotReqDto.time(), resume);
-            timeSlotRepository.save(timeSlot);
-        });
+        List<TimeSlot> result = timeSlots.stream().map(
+                timeslot -> TimeSlot.of(timeslot.time(), resume)
+        ).toList();
+        timeSlotRepository.saveAll(result);
+
+//        timeSlots.forEach(timeSlotReqDto -> {
+//            TimeSlot timeSlot = TimeSlot.of(timeSlotReqDto.time(), resume);
+//            timeSlotRepository.save(timeSlot);
+//        });
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -1,0 +1,4 @@
+package com.tave.tavewebsite.domain.resume.service;
+
+public class TimeSlotServiceImpl implements TimeSlotService {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImpl.java
@@ -1,4 +1,47 @@
 package com.tave.tavewebsite.domain.resume.service;
 
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotReqDto;
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotResDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
+import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
+import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import com.tave.tavewebsite.domain.resume.repository.TimeSlotRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
 public class TimeSlotServiceImpl implements TimeSlotService {
+
+    private final ResumeRepository resumeRepository;
+    private final TimeSlotRepository timeSlotRepository;
+
+    @Transactional
+    @Override
+    public void createTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlots) {
+        Resume resume = findIfResumeExists(resumeId);
+
+        timeSlots.forEach(timeSlotReqDto -> {
+            TimeSlot timeSlot = TimeSlot.of(timeSlotReqDto.time(), resume);
+            timeSlotRepository.save(timeSlot);
+        });
+    }
+
+    @Override
+    public void updateTimeSlot(Long resumeId, List<TimeSlotReqDto> timeSlot) {
+
+    }
+
+    @Override
+    public List<TimeSlotResDto> getTimeSlots(Long resumeId) {
+        return List.of();
+    }
+
+    private Resume findIfResumeExists(Long resumeId) {
+        return resumeRepository.findById(resumeId).orElseThrow(ResumeNotFoundException::new);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/AuthorizedException.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/AuthorizedException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.global.security.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.global.security.exception.ErrorType.NOT_AUTHORIZED;
+
+public class AuthorizedException extends BaseErrorException {
+    public AuthorizedException() {
+        super(NOT_AUTHORIZED.getCode(), NOT_AUTHORIZED.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/global/security/exception/ErrorType.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/exception/ErrorType.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.global.security.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorType {
+
+    NOT_AUTHORIZED(403, "회원 정보가 유효하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/global/security/utils/SecurityUtils.java
+++ b/src/main/java/com/tave/tavewebsite/global/security/utils/SecurityUtils.java
@@ -1,0 +1,27 @@
+package com.tave.tavewebsite.global.security.utils;
+
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.global.security.exception.AuthorizedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Slf4j
+@Configuration
+public class SecurityUtils {
+
+    public static Member getCurrentMember() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.info("Current user: {}", authentication.getPrincipal());
+        log.info("Current username: {}", authentication.getName());
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthorizedException();
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        return (Member) principal;
+    }
+}

--- a/src/test/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImplTest.java
+++ b/src/test/java/com/tave/tavewebsite/domain/resume/service/TimeSlotServiceImplTest.java
@@ -1,0 +1,71 @@
+package com.tave.tavewebsite.domain.resume.service;
+
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotReqDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.entity.TimeSlot;
+import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import com.tave.tavewebsite.domain.resume.repository.TimeSlotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TimeSlotServiceImplTest {
+
+    @Mock
+    private ResumeRepository resumeRepository;
+
+    @Mock
+    private TimeSlotRepository timeSlotRepository;
+
+    @InjectMocks
+    private TimeSlotServiceImpl timeSlotService;
+
+    @DisplayName("체크한 면접 가능 시간을 DB에 저장합니다.")
+    @Test
+    void createTimeSlot() {
+        // Given
+        // Resume 도메인 객체를 생성(빌더를 사용하거나, 간단히 new Resume() 후 id를 설정)
+        Member member = mock(Member.class);
+
+        // 실제 Resume 객체를 생성 (빌더 패턴 사용)
+        Resume resumeReal = Resume.builder()
+                .school("세종대")
+                .major("경영학과")
+                .resumeGeneration(15)
+                .blogUrl("www.blog.com")
+                .githubUrl("www.github.com")
+                .state("미정")
+                .field("BACKEND")
+                .member(member)
+                .build();
+
+        // spy를 사용하여 실제 객체의 동작을 유지하면서 getId()만 오버라이드
+        Resume resume = spy(resumeReal);
+        ReflectionTestUtils.setField(resume, "id", 1L);
+
+        when(resumeRepository.findById(resume.getId())).thenReturn(Optional.of(resume));
+
+        List<TimeSlotReqDto> reqDtos = new ArrayList<>();
+        reqDtos.add(new TimeSlotReqDto("2025/04/20 15:30"));
+
+        // When
+        timeSlotService.createTimeSlot(1L, reqDtos);
+
+        // Then
+        verify(timeSlotRepository, times(reqDtos.size())).save(any(TimeSlot.class));
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #83 
> Close #83 

## 📑 작업 내용
> - 동아리 지원 시 면접에 대해 가능한 시간대를 생성 및 조회하는 기능을 구현합니다.

## ✂️ 스크린샷 (선택)
> 우선 면접 시간 엔티티에 대한 생성자 빌더 패턴을 적용합니다.
> 후에 면접 시간에 대한 CRU 기능을 구현합니다. 이때 이력서에 대한 유효성 검증을 실시하며 검증이 완료되면 로직을 실행합니다.
> 면접 시간 정보 저장은 stream을 사용하여 간략한 코드로 각 reqDto가 timeSlotRepository에 저장되도록 하였습니다.
<img width="611" alt="image" src="https://github.com/user-attachments/assets/f32da73a-872a-44bb-816e-608a6c8b5c26" />
<img width="750" alt="image" src="https://github.com/user-attachments/assets/44f3d930-bac1-4261-b471-ac4d4c323d66" />

> 면접 시간에 대한 기능 테스트를 위해 테스트 클래스를 작성하여 면접 시간 생성에 대한 메서드만 테스트 하였습니다.
> 이때 Mock을 사용하여 가짜 객체를 생성하고 동작을 수행하여 정상적으로 저장되는지 테스트 해보았습니다.
<img width="755" alt="image" src="https://github.com/user-attachments/assets/9f48e2ac-9491-4543-b57b-996b6386fe94" />
<img width="275" alt="image" src="https://github.com/user-attachments/assets/dcfc1d03-8922-4192-8dbb-79b07f2e9b62" />



## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
