### PR TITLE
[feat] 지원서 개인정보 crud

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -31,4 +31,12 @@ public class PersonalInfoController {
         return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
                 PersonalInfoSuccessMessage.READ_SUCCESS.getMessage());
     }
+
+    // 개인정보 수정
+    @PatchMapping("/{resumeId}")
+    public SuccessResponse updatePersonalInfo(@PathVariable("resumeId") Long resumeId,
+                                              @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.updatePersonalInfo(resumeId, requestDto);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.UPDATE_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -39,4 +39,11 @@ public class PersonalInfoController {
         personalInfoService.updatePersonalInfo(resumeId, requestDto);
         return SuccessResponse.ok(PersonalInfoSuccessMessage.UPDATE_SUCCESS.getMessage());
     }
+
+    // 개인정보 삭제
+    @DeleteMapping("/{resumeId}")
+    public SuccessResponse deletePersonalInfo(@PathVariable("resumeId") Long resumeId) {
+        personalInfoService.deletePersonalInfo(resumeId);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.DELETE_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -1,0 +1,57 @@
+package com.tave.tavewebsite.domain.resume.controller;
+
+import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
+import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+@RequestMapping("/v1/normal/info")
+public class PersonalInfoController {
+
+    private final PersonalInfoService personalInfoService;
+
+    // 개인정보 저장 (새로운 지원서 생성)
+    @PostMapping("/{memberId}")
+    public SuccessResponse createPersonalInfo(@PathVariable("memberId") Long memberId,
+                                              @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.createPersonalInfo(memberId, requestDto);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
+    }
+
+    // 개인정보 조회
+    @GetMapping("/{resumeId}")
+    public SuccessResponse<PersonalInfoResponseDto> getPersonalInfo(@PathVariable("resumeId") Long resumeId) {
+        return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
+                PersonalInfoSuccessMessage.READ_SUCCESS.getMessage());
+    }
+
+    // 개인정보 수정
+    @PatchMapping("/{resumeId}")
+    public SuccessResponse updatePersonalInfo(@PathVariable("resumeId") Long resumeId,
+                                              @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.updatePersonalInfo(resumeId, requestDto);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.UPDATE_SUCCESS.getMessage());
+    }
+
+    // 개인정보 삭제
+    @DeleteMapping("/{resumeId}")
+    public SuccessResponse deletePersonalInfo(@PathVariable("resumeId") Long resumeId) {
+        personalInfoService.deletePersonalInfo(resumeId);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.DELETE_SUCCESS.getMessage());
+    }
+
+    // 임시 저장
+    @PostMapping("/temp-save/{memberId}")
+    public SuccessResponse tempSavePersonalInfo(@PathVariable("memberId") Long memberId,
+                                                @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.tempSavePersonalInfo(memberId, requestDto);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.TEMP_SAVE_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -46,4 +46,12 @@ public class PersonalInfoController {
         personalInfoService.deletePersonalInfo(resumeId);
         return SuccessResponse.ok(PersonalInfoSuccessMessage.DELETE_SUCCESS.getMessage());
     }
+
+    // 임시 저장
+    @PostMapping("/temp-save/{memberId}")
+    public SuccessResponse tempSavePersonalInfo(@PathVariable("memberId") Long memberId,
+                                                @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.tempSavePersonalInfo(memberId, requestDto);
+        return SuccessResponse.ok(PersonalInfoSuccessMessage.TEMP_SAVE_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -1,7 +1,6 @@
 package com.tave.tavewebsite.domain.resume.controller;
 
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
-import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
@@ -23,35 +22,5 @@ public class PersonalInfoController {
                                               @RequestBody @Valid PersonalInfoRequestDto requestDto) {
         personalInfoService.createPersonalInfo(memberId, requestDto);
         return SuccessResponse.ok(PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
-    }
-
-    // 개인정보 조회
-    @GetMapping("/{resumeId}")
-    public SuccessResponse<PersonalInfoResponseDto> getPersonalInfo(@PathVariable("resumeId") Long resumeId) {
-        return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
-                PersonalInfoSuccessMessage.READ_SUCCESS.getMessage());
-    }
-
-    // 개인정보 수정
-    @PatchMapping("/{resumeId}")
-    public SuccessResponse updatePersonalInfo(@PathVariable("resumeId") Long resumeId,
-                                              @RequestBody @Valid PersonalInfoRequestDto requestDto) {
-        personalInfoService.updatePersonalInfo(resumeId, requestDto);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.UPDATE_SUCCESS.getMessage());
-    }
-
-    // 개인정보 삭제
-    @DeleteMapping("/{resumeId}")
-    public SuccessResponse deletePersonalInfo(@PathVariable("resumeId") Long resumeId) {
-        personalInfoService.deletePersonalInfo(resumeId);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.DELETE_SUCCESS.getMessage());
-    }
-
-    // 임시 저장
-    @PostMapping("/temp-save/{memberId}")
-    public SuccessResponse tempSavePersonalInfo(@PathVariable("memberId") Long memberId,
-                                                @RequestBody @Valid PersonalInfoRequestDto requestDto) {
-        personalInfoService.tempSavePersonalInfo(memberId, requestDto);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.TEMP_SAVE_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.resume.controller;
 
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
@@ -22,5 +23,12 @@ public class PersonalInfoController {
                                               @RequestBody @Valid PersonalInfoRequestDto requestDto) {
         personalInfoService.createPersonalInfo(memberId, requestDto);
         return SuccessResponse.ok(PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
+    }
+
+    // 개인정보 조회
+    @GetMapping("/{resumeId}")
+    public SuccessResponse<PersonalInfoResponseDto> getPersonalInfo(@PathVariable("resumeId") Long resumeId) {
+        return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
+                PersonalInfoSuccessMessage.READ_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
@@ -1,0 +1,18 @@
+package com.tave.tavewebsite.domain.resume.controller;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PersonalInfoSuccessMessage {
+    CREATE_SUCCESS("개인정보 작성에 성공했습니다."),
+    UPDATE_SUCCESS("개인정보 수정에 성공했습니다."),
+    READ_SUCCESS("개인정보 조회에 성공했습니다."),
+    DELETE_SUCCESS("개인정보 삭제에 성공했습니다."),
+    TEMP_SAVE_SUCCESS("임시 저장에 성공했습니다.");
+
+    private final String message;
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/PersonalInfoRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/PersonalInfoRequestDto.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.domain.resume.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+
+@Getter
+public class PersonalInfoRequestDto {
+    @NotNull
+    @Size(min = 1, max = 20)
+    private String school;
+
+    @NotNull
+    @Size(max = 30)
+    private String major;
+
+    @Size(max = 30)
+    private String minor;
+
+    @NotNull
+    private String field;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
@@ -1,19 +1,13 @@
 package com.tave.tavewebsite.domain.resume.dto.response;
 
-import com.tave.tavewebsite.domain.resume.entity.Resume;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class PersonalInfoResponseDto {
     private final String school;
     private final String major;
     private final String minor;
     private final String field;
-
-    public PersonalInfoResponseDto(Resume resume) {
-        this.school = resume.getSchool();
-        this.major = resume.getMajor();
-        this.minor = resume.getMinor();
-        this.field = resume.getField();
-    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
@@ -1,0 +1,19 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import lombok.Getter;
+
+@Getter
+public class PersonalInfoResponseDto {
+    private final String school;
+    private final String major;
+    private final String minor;
+    private final String field;
+
+    public PersonalInfoResponseDto(Resume resume) {
+        this.school = resume.getSchool();
+        this.major = resume.getMajor();
+        this.minor = resume.getMinor();
+        this.field = resume.getField();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.resume.entity;
 
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -110,11 +111,11 @@ public class Resume {
         this.languageLevels.add(languageLevel);
     }
 
-    public void updatePersonalInfo(String school, String major, String minor, String field) {
-        this.school = school;
-        this.major = major;
-        this.minor = minor;
-        this.field = field;
+    public void updatePersonalInfo(PersonalInfoRequestDto requestDto) {
+        this.school = requestDto.getSchool();
+        this.major = requestDto.getMajor();
+        this.minor = requestDto.getMinor();
+        this.field = requestDto.getField();
     }
 
     public enum FieldType {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -2,18 +2,14 @@ package com.tave.tavewebsite.domain.resume.entity;
 
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,8 +41,8 @@ public class Resume {
     @Column(length = 8)
     private String field;
 
-    @Size(min = 1, max = 5)
-    @Column(length = 5)
+    @Min(1)
+    @Max(5)
     private Integer resumeGeneration;
 
     @Size(min = 1, max = 50)
@@ -112,5 +108,31 @@ public class Resume {
 
     public void addLanguageLevel(LanguageLevel languageLevel) {
         this.languageLevels.add(languageLevel);
+    }
+
+    public void updatePersonalInfo(String school, String major, String minor, String field) {
+        this.school = school;
+        this.major = major;
+        this.minor = minor;
+        this.field = field;
+    }
+
+    public enum FieldType {
+        DESIGNER("designer"),
+        WEBFRONTEND("Web Frontend"),
+        APPFRONTEND("App Frontend"),
+        BACKEND("Backend"),
+        DATAANALYSIS("Data Analysis"),
+        DEEPLEARNING("Deep Learning");
+
+        private final String message;
+
+        FieldType(String message) {
+            this.message = message;
+        }
+
+        public String getMessage() {
+            return message;
+        }
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -37,7 +37,7 @@ public class Resume {
     @Column(length = 20)
     private String minor;
 
-    @Size(min = 1, max = 8)
+    @Size(min = 1, max = 15)
     @Column(length = 8)
     private String field;
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.resume.exception;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    RESUME_NOT_FOUND(400, "해당 회원의 이력서가 존재하지 않습니다."),
+    MEMBER_NOT_FOUND(400, "회원이 존재하지 않습니다."),
+    INVALID_FIELD(400, "지원 분야가 올바르지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidFieldException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidFieldException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.INVALID_FIELD;
+
+public class InvalidFieldException extends BaseErrorException {
+    public InvalidFieldException() {
+      super(INVALID_FIELD.getCode(), INVALID_FIELD.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/MemberNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/MemberNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.MEMBER_NOT_FOUND;
+
+public class MemberNotFoundException extends BaseErrorException {
+  public MemberNotFoundException() {
+    super(MEMBER_NOT_FOUND.getCode(), MEMBER_NOT_FOUND.getMessage());
+  }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ResumeNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ResumeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.RESUME_NOT_FOUND;
+
+public class ResumeNotFoundException extends BaseErrorException {
+    public ResumeNotFoundException() {
+        super(RESUME_NOT_FOUND.getCode(), RESUME_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/mapper/ResumeMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/mapper/ResumeMapper.java
@@ -1,0 +1,28 @@
+package com.tave.tavewebsite.domain.resume.mapper;
+
+import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.member.entity.Member;
+
+public class ResumeMapper {
+
+    public static Resume toResume(PersonalInfoRequestDto requestDto, Member member) {
+        return Resume.builder()
+                .member(member)
+                .school(requestDto.getSchool())
+                .major(requestDto.getMajor())
+                .minor(requestDto.getMinor())
+                .field(requestDto.getField())
+                .build();
+    }
+
+    public static PersonalInfoResponseDto toPersonalInfoResponseDto(Resume resume) {
+        return new PersonalInfoResponseDto(
+                resume.getSchool(),
+                resume.getMajor(),
+                resume.getMinor(),
+                resume.getField()
+        );
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -6,10 +6,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 
     @Query("select r from Resume r join fetch r.languageLevels join fetch r.member where r.id = :id")
     Resume findResumeWithLanguageLevels(@Param("id") Long id);
 
+    Optional<Resume> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -28,14 +28,8 @@ public class PersonalInfoService {
         Resume resume = ResumeMapper.toResume(requestDto, member);
         resumeRepository.save(resume);
 
-        // 지원 분야 값 검증
-        String field = requestDto.getField();
-        Resume.FieldType fieldType;
-        try {
-            fieldType = Resume.FieldType.valueOf(field.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new ResumeNotFoundException();
-        }
+        // 지원 분야 값 검증 및 변환
+        Resume.FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
 
         // 개인 정보 저장
         resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
@@ -82,4 +76,12 @@ public class PersonalInfoService {
         resumeRepository.delete(resume);
     }
 
+    // 지원 분야 값 검증 및 변환 메서드
+    private Resume.FieldType validateAndConvertFieldType(String field) {
+        try {
+            return Resume.FieldType.valueOf(field.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ResumeNotFoundException();
+        }
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -47,6 +47,18 @@ public class PersonalInfoService {
         resumeRepository.save(resume);
     }
 
+    // 임시 저장 기능 (현재까지 입력한 정보 저장)
+    @Transactional
+    public void tempSavePersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
+        Resume resume = resumeRepository.findByMemberId(memberId)
+                .orElseThrow(ResumeNotFoundException::new);
+
+        // 기존 정보 갱신(임시 저장 위해)
+        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
+                requestDto.getMinor(), requestDto.getField());
+
+    }
+
     public PersonalInfoResponseDto getPersonalInfo(Long resumeId) {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -29,9 +29,9 @@ public class PersonalInfoService {
         Resume.FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
 
         Resume resume = ResumeMapper.toResume(requestDto, member);
-        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
-                requestDto.getMinor(), fieldType.getMessage());
+        resumeRepository.save(resume);
 
+        resume.updatePersonalInfo(requestDto);
         resumeRepository.save(resume);
     }
 
@@ -41,10 +41,8 @@ public class PersonalInfoService {
         Resume resume = resumeRepository.findByMemberId(memberId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        // 기존 정보 갱신(임시 저장 위해)
-        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
-                requestDto.getMinor(), requestDto.getField());
-
+        // 기존 정보 갱신 (임시 저장 위해)
+        resume.updatePersonalInfo(requestDto);
     }
 
     public PersonalInfoResponseDto getPersonalInfo(Long resumeId) {
@@ -59,11 +57,10 @@ public class PersonalInfoService {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        String field = requestDto.getField();
-        Resume.FieldType fieldType = Resume.FieldType.valueOf(field.toUpperCase());
+        // 지원 분야 값 검증 및 변환
+        Resume.FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
 
-        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
-                requestDto.getMinor(), fieldType.getMessage());
+        resume.updatePersonalInfo(requestDto);
     }
 
     @Transactional

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.resume.service;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.exception.MemberNotFoundException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
@@ -44,6 +45,13 @@ public class PersonalInfoService {
         resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
                 requestDto.getMinor(), fieldType.getMessage());
         resumeRepository.save(resume);
+    }
+
+    public PersonalInfoResponseDto getPersonalInfo(Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(ResumeNotFoundException::new);
+
+        return new PersonalInfoResponseDto(resume);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -54,4 +54,16 @@ public class PersonalInfoService {
         return new PersonalInfoResponseDto(resume);
     }
 
+    @Transactional
+    public void updatePersonalInfo(Long resumeId, PersonalInfoRequestDto requestDto) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(ResumeNotFoundException::new);
+
+        String field = requestDto.getField();
+        Resume.FieldType fieldType = Resume.FieldType.valueOf(field.toUpperCase());
+
+        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
+                requestDto.getMinor(), fieldType.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -1,0 +1,49 @@
+package com.tave.tavewebsite.domain.resume.service;
+
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
+import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.exception.MemberNotFoundException;
+import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
+import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalInfoService {
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+
+    // 개인정보 저장
+    @Transactional
+    public void createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Resume resume = Resume.builder()
+                .member(member)
+                .school(requestDto.getSchool())
+                .major(requestDto.getMajor())
+                .minor(requestDto.getMinor())
+                .field(requestDto.getField())
+                .build();
+
+        // 지원 분야 값 검증
+        String field = requestDto.getField();
+        Resume.FieldType fieldType;
+        try{
+            fieldType = Resume.FieldType.valueOf(field.toUpperCase());
+        } catch (IllegalArgumentException e){
+            throw new ResumeNotFoundException();
+        }
+
+        // 개인 정보 저장
+        resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
+                requestDto.getMinor(), fieldType.getMessage());
+        resumeRepository.save(resume);
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -7,6 +7,7 @@ import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.exception.MemberNotFoundException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
+import com.tave.tavewebsite.domain.resume.mapper.ResumeMapper;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -24,20 +25,15 @@ public class PersonalInfoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        Resume resume = Resume.builder()
-                .member(member)
-                .school(requestDto.getSchool())
-                .major(requestDto.getMajor())
-                .minor(requestDto.getMinor())
-                .field(requestDto.getField())
-                .build();
+        Resume resume = ResumeMapper.toResume(requestDto, member);
+        resumeRepository.save(resume);
 
         // 지원 분야 값 검증
         String field = requestDto.getField();
         Resume.FieldType fieldType;
-        try{
+        try {
             fieldType = Resume.FieldType.valueOf(field.toUpperCase());
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             throw new ResumeNotFoundException();
         }
 
@@ -63,7 +59,7 @@ public class PersonalInfoService {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        return new PersonalInfoResponseDto(resume);
+        return ResumeMapper.toPersonalInfoResponseDto(resume);
     }
 
     @Transactional

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -66,4 +66,12 @@ public class PersonalInfoService {
                 requestDto.getMinor(), fieldType.getMessage());
     }
 
+    @Transactional
+    public void deletePersonalInfo(Long resumeId) {
+        Resume resume = resumeRepository.findById(resumeId)
+                .orElseThrow(ResumeNotFoundException::new);
+
+        resumeRepository.delete(resume);
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -25,15 +25,13 @@ public class PersonalInfoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        Resume resume = ResumeMapper.toResume(requestDto, member);
-        resumeRepository.save(resume);
-
         // 지원 분야 값 검증 및 변환
         Resume.FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
 
-        // 개인 정보 저장
+        Resume resume = ResumeMapper.toResume(requestDto, member);
         resume.updatePersonalInfo(requestDto.getSchool(), requestDto.getMajor(),
                 requestDto.getMinor(), fieldType.getMessage());
+
         resumeRepository.save(resume);
     }
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #88
> Close #88

## 📑 작업 내용
> - 지원서 작성 시 회원이 입력해야 할 내용은 학교이름, 전공, 부전공, 지원분야 입니다.
> - memberId를 사용해 지원서 입력, 임시저장 기능을 구현했습니다. 
> - resumeId를 사용해 지원서 조회, 수정, 삭제 기능을 구현했습니다.
> - resume entity에 지원서 입력 시 필요한 field를 구현했습니다. (field max 길이 늘렸습니다.)
> - 지원서에서 사용되는 지원 분야를 FieldType enum으로 정의했습니다.
> - Resume 객체 생성 시 @Builder 패턴을 사용하여 더 직관적이고 안전하게 객체를 생성할 수 있도록 했습니다.


## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
