### PR TITLE
[fix] 지원서 개인정보 입력 api 엔드포인트 일반 회원으로 변경

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/v1/normal/info")
+@RequestMapping("/v1/member/info")
 public class PersonalInfoController {
 
     private final PersonalInfoService personalInfoService;


### PR DESCRIPTION
## ➕ 연관된 이슈
> #97
> Close #97

## 📑 작업 내용
> - 지원서 개인정보 관련 api 엔드포인트를 일반 회원인 /member 로 변경

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
