### PR TITLE
[Fix] RequestBody를 받기 위한 메서드 유형 수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -37,7 +37,7 @@ public class ManagerController {
         return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }
 
-    @GetMapping("/normal/verify/number")
+    @PostMapping("/normal/verify/number")
     public SuccessResponse verifyNumber(@RequestBody ValidateEmailReq requestDto) {
         memberService.verityNumber(requestDto);
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #90 
> Close #90 

## 📑 작업 내용
> - 이번 PR에서 작업한 내용 간략히 설명해주세요
RequestBody를 통해 전달해야하는 인증번호 유효검사 API를 GetMapping으로 설정하여 API 통신이 이루어지지 않는 오류가 발생하였습니다.
이를 PostMapping으로 수정하여 통신되도록 하였습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
