### PR TITLE
[fix] 일반 회원가입 패키지 위치 수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.member.controller;
 
 import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.RegisterMemberRequestDto;
 import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
 import com.tave.tavewebsite.domain.member.dto.response.RefreshResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
@@ -22,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.tave.tavewebsite.domain.member.controller.MemberSuccessMessage.NORMAL_MEMBER_SIGNUP;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/v1/auth")
@@ -34,6 +37,13 @@ public class AuthController {
     public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
         MailResponseDto response = memberService.saveMember(requestDto);
         return new SuccessResponse<>(response);
+    }
+
+    @PostMapping("/normal/signup")
+    public SuccessResponse registerMember(@RequestBody @Valid RegisterMemberRequestDto dto){
+        memberService.saveNormalMember(dto);
+
+        return SuccessResponse.ok(NORMAL_MEMBER_SIGNUP.getMessage());
     }
 
     @PostMapping("/signin")

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -21,13 +21,6 @@ public class ManagerController {
     private final MemberService memberService;
     private final AdminService adminService;
 
-    @PostMapping("/normal/signup")
-    public SuccessResponse registerMember(@RequestBody @Valid RegisterMemberRequestDto dto){
-        memberService.saveNormalMember(dto);
-
-        return SuccessResponse.ok(NORMAL_MEMBER_SIGNUP.getMessage());
-    }
-
     @PostMapping("/normal/authenticate/email")
     public SuccessResponse sendEmail(@RequestBody ValidateEmailReq requestDto,
                                      @RequestParam(required = false, defaultValue = "false") Boolean reset) {


### PR DESCRIPTION
## ➕ 연관된 이슈
> #82 
> Close #82 

## 📑 작업 내용
> -  일반 회원가입 패키지 위치를 수정합니다.

기존 ManagerController에 위치한 **일반 회원가입**을 AuthController로 이동시켰습니다.

최종 엔드포인트는 /v1/auth/normal/signup 입니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

기존 **관리자 회원가입**의 엔드포인트는 /v1/auth/signup입니다.
추가된 코드와 통일성을 맞추기 위해서 /v1/auth/manager/signup 으로 변경하는 건 어떨 지 팀원들 과 이야기 나누고 싶습니다!

``` java
// 기존
// 관리자 회원가입
"/v1/auth/signup"
// 일반 회원가입
"/v1/auth/normal/signup"

// 건의사항
// 관리자 회원가입
"/v1/auth/manager/signup"
// 일반 회원가입
"/v1/auth/normal/signup"

```
