### PR TITLE
fix: 회원가입 시 이메일 인증 재수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/ManagerController.java
@@ -38,8 +38,9 @@ public class ManagerController {
     }
 
     @PostMapping("/normal/verify/number")
-    public SuccessResponse verifyNumber(@RequestBody ValidateEmailReq requestDto) {
-        memberService.verityNumber(requestDto);
+    public SuccessResponse verifyNumber(@RequestBody ValidateEmailReq requestDto,
+                                        @RequestParam(required = false, defaultValue = "false") Boolean reset) {
+        memberService.verityNumber(requestDto, reset);
 
         return SuccessResponse.ok(MemberSuccessMessage.VERIFY_SUCCESS.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -59,8 +59,12 @@ public class MemberService {
         mailService.sendAuthenticationCode(req.email());
     }
 
-    public void verityNumber(ValidateEmailReq req) {
-        memberRepository.findByEmail(req.email()).orElseThrow(NotFoundMemberException::new);
+    public void verityNumber(ValidateEmailReq req, Boolean reset) {
+        if(reset.equals(Boolean.FALSE))
+            validateEmail(req.email());
+        else
+            findIfEmailExists(req.email());
+
         String validatedNumber = (String) redisUtil.get(req.email());
 
         if (!req.number().equals(validatedNumber)) {

--- a/src/test/java/com/tave/tavewebsite/global/s3/service/S3ServiceTest.java
+++ b/src/test/java/com/tave/tavewebsite/global/s3/service/S3ServiceTest.java
@@ -1,0 +1,49 @@
+package com.tave.tavewebsite.global.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class S3ServiceTest {
+
+    private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        AmazonS3 s3Client = mock(AmazonS3.class);
+        s3Service = new S3Service(s3Client, "hihi"); // 생성자 주입 방식
+    }
+
+    @DisplayName("MultipartFile을 .webp으로 업로드합니다.")
+    @Test
+    void convertToWebp() throws Exception {
+     //given
+        byte[] dummyImage = Files.readAllBytes(Paths.get("src/test/resources/sample.jpg"));
+        MockMultipartFile multipartFile = new MockMultipartFile(
+                "file", "sample.jpg", "image/jpeg", dummyImage
+        );
+
+        String fileName = multipartFile.getOriginalFilename();
+
+     //when
+        File resultFile = s3Service.convertToWebp(fileName, multipartFile);
+        System.out.println(resultFile.getName());
+
+     //then
+        assertThat(resultFile).exists();
+        assertThat(resultFile.getName()).endsWith(".webp");
+
+        resultFile.delete();
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #90 
> Close #90 

## 📑 작업 내용
> - 회원가입/비밀번호 찾기 별로 수행하는 한 메서드에 대해 파라미터에 따라 분리하였습니다. 
> - webp 형식으로 변환되는 파일에 대한 테스트 코드를 작성하였습니다. 그 결과, 기존 파일 확장자 + .webp으로 저장이 되는 사항을 발견했습니다.

## ✂️ 스크린샷 (선택)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/44675f23-7b12-400f-8467-c1dbbf8ca06b" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
