### PR TITLE
[feat] 일반회원 비밀번호 찾기

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -1,11 +1,9 @@
 package com.tave.tavewebsite.domain.member.controller;
 
-import com.tave.tavewebsite.domain.member.dto.request.RefreshTokenRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.RegisterMemberRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.SignUpRequestDto;
+import com.tave.tavewebsite.domain.member.dto.request.*;
 import com.tave.tavewebsite.domain.member.dto.response.RefreshResponseDto;
 import com.tave.tavewebsite.domain.member.dto.response.SignInResponseDto;
+import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.service.AuthService;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.mail.dto.MailResponseDto;
@@ -13,15 +11,7 @@ import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.tave.tavewebsite.domain.member.controller.MemberSuccessMessage.NORMAL_MEMBER_SIGNUP;
 
@@ -40,7 +30,7 @@ public class AuthController {
     }
 
     @PostMapping("/normal/signup")
-    public SuccessResponse registerMember(@RequestBody @Valid RegisterMemberRequestDto dto){
+    public SuccessResponse registerMember(@RequestBody @Valid RegisterMemberRequestDto dto) {
         memberService.saveNormalMember(dto);
 
         return SuccessResponse.ok(NORMAL_MEMBER_SIGNUP.getMessage());
@@ -70,5 +60,11 @@ public class AuthController {
     public SuccessResponse deleteMember(@PathVariable("memberId") Long memberId) {
         memberService.deleteMember(memberId);
         return SuccessResponse.ok(MemberSuccessMessage.DELETE_MEMBER_SUCCESS.getMessage());
+    }
+
+    @PostMapping("/normal/reset/verify")
+    public SuccessResponse sendPasswordResetCode(@RequestBody ResetPasswordVerifyRequestDto requestDto) {
+        memberService.verifyNormalMemberForPasswordReset(requestDto);
+        return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -73,4 +73,10 @@ public class AuthController {
         memberService.verifyAuthCodeForPasswordReset(email, code);
         return SuccessResponse.ok(MemberSuccessMessage.VERIFY_SUCCESS.getMessage());
     }
+
+    @PostMapping("/normal/reset/password")
+    public SuccessResponse resetNormalPassword(@RequestBody @Valid ResetNormalPasswordRequestDto requestDto) {
+        memberService.resetNormalMemberPassword(requestDto);
+        return SuccessResponse.ok(MemberSuccessMessage.RESET_PASSWORD.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -17,64 +17,64 @@ import static com.tave.tavewebsite.domain.member.controller.MemberSuccessMessage
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/auth")
+@RequestMapping("/v1")
 public class AuthController {
 
     private final MemberService memberService;
     private final AuthService authService;
 
-    @PostMapping("/signup")
+    @PostMapping("/auth/signup")
     public SuccessResponse<MailResponseDto> registerManager(@RequestBody @Valid RegisterManagerRequestDto requestDto) {
         MailResponseDto response = memberService.saveMember(requestDto);
         return new SuccessResponse<>(response);
     }
 
-    @PostMapping("/normal/signup")
+    @PostMapping("/auth/normal/signup")
     public SuccessResponse registerMember(@RequestBody @Valid RegisterMemberRequestDto dto) {
         memberService.saveNormalMember(dto);
 
         return SuccessResponse.ok(NORMAL_MEMBER_SIGNUP.getMessage());
     }
 
-    @PostMapping("/signin")
+    @PostMapping("/auth/signin")
     public SuccessResponse<SignInResponseDto> signIn(@RequestBody SignUpRequestDto requestDto,
                                                      HttpServletResponse response) {
         SignInResponseDto signInResponseDto = authService.signIn(requestDto, response);
         return new SuccessResponse<>(signInResponseDto);
     }
 
-    @PostMapping("/refresh")
+    @PostMapping("/auth/refresh")
     public SuccessResponse<RefreshResponseDto> refreshToken(@RequestBody RefreshTokenRequestDto requestDto,
                                                             @CookieValue("refreshToken") String refreshToken,
                                                             HttpServletResponse response) {
         return new SuccessResponse<>(authService.reissueToken(requestDto, refreshToken, response));
     }
 
-    @GetMapping("/signout")
+    @GetMapping("/auth/signout")
     public SuccessResponse signOut(@RequestHeader("Authorization") String token, HttpServletResponse response) {
         authService.singOut(token, response);
         return SuccessResponse.ok(MemberSuccessMessage.SIGN_OUT_SUCCESS.getMessage());
     }
 
-    @DeleteMapping("/delete/{memberId}")
+    @DeleteMapping("/auth/delete/{memberId}")
     public SuccessResponse deleteMember(@PathVariable("memberId") Long memberId) {
         memberService.deleteMember(memberId);
         return SuccessResponse.ok(MemberSuccessMessage.DELETE_MEMBER_SUCCESS.getMessage());
     }
 
-    @PostMapping("/reset/verify")
+    @PostMapping("/normal/reset/verify")
     public SuccessResponse sendPasswordResetCode(@RequestBody ResetPasswordVerifyRequestDto requestDto) {
         memberService.verifyNormalMemberForPasswordReset(requestDto);
         return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }
 
-    @PostMapping("/reset/verify/code")
+    @PostMapping("/normal/reset/verify/code")
     public SuccessResponse verifyResetCode(@RequestParam String email, @RequestParam String code) {
         memberService.verifyAuthCodeForPasswordReset(email, code);
         return SuccessResponse.ok(MemberSuccessMessage.VERIFY_SUCCESS.getMessage());
     }
 
-    @PostMapping("/reset/password")
+    @PostMapping("/normal/password/change")
     public SuccessResponse resetNormalPassword(@RequestBody @Valid ResetNormalPasswordRequestDto requestDto) {
         memberService.resetNormalMemberPassword(requestDto);
         return SuccessResponse.ok(MemberSuccessMessage.RESET_PASSWORD.getMessage());

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -62,19 +62,19 @@ public class AuthController {
         return SuccessResponse.ok(MemberSuccessMessage.DELETE_MEMBER_SUCCESS.getMessage());
     }
 
-    @PostMapping("/normal/reset/verify")
+    @PostMapping("/reset/verify")
     public SuccessResponse sendPasswordResetCode(@RequestBody ResetPasswordVerifyRequestDto requestDto) {
         memberService.verifyNormalMemberForPasswordReset(requestDto);
         return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }
 
-    @PostMapping("/normal/reset/verify/code")
+    @PostMapping("/reset/verify/code")
     public SuccessResponse verifyResetCode(@RequestParam String email, @RequestParam String code) {
         memberService.verifyAuthCodeForPasswordReset(email, code);
         return SuccessResponse.ok(MemberSuccessMessage.VERIFY_SUCCESS.getMessage());
     }
 
-    @PostMapping("/normal/reset/password")
+    @PostMapping("/reset/password")
     public SuccessResponse resetNormalPassword(@RequestBody @Valid ResetNormalPasswordRequestDto requestDto) {
         memberService.resetNormalMemberPassword(requestDto);
         return SuccessResponse.ok(MemberSuccessMessage.RESET_PASSWORD.getMessage());

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -67,4 +67,10 @@ public class AuthController {
         memberService.verifyNormalMemberForPasswordReset(requestDto);
         return SuccessResponse.ok(MemberSuccessMessage.SEND_AUTHENTICATION_CODE.getMessage());
     }
+
+    @PostMapping("/normal/reset/verify/code")
+    public SuccessResponse verifyResetCode(@RequestParam String email, @RequestParam String code) {
+        memberService.verifyAuthCodeForPasswordReset(email, code);
+        return SuccessResponse.ok(MemberSuccessMessage.VERIFY_SUCCESS.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/MemberSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/MemberSuccessMessage.java
@@ -17,7 +17,7 @@ public enum MemberSuccessMessage {
     SEND_AUTHENTICATION_CODE("인증번호 발송에 성공했습니다."),
     VERIFY_SUCCESS("인증에 성공했습니다."),
     CAN_USE_NICKNAME("닉네임 사용 가능합니다."),
-    RESET_PASSWORD("비밀번호가 재설정되었습니다.\n 다시 로그인해주세요."),
+    RESET_PASSWORD("비밀번호가 재설정되었습니다. 다시 로그인해주세요."),
 
     MANAGER_APPROVED("대기 운영진이 승인되었습니다."),
     MANAGER_REJECTED("대기 운영진이 거절되었습니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetNormalPasswordRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetNormalPasswordRequestDto.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.member.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+
+public record ResetNormalPasswordRequestDto(
+        String email,
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\W).+$",
+                message = "비밀번호는 8자 이상이어야 하며, 대문자, 소문자, 특수문자를 포함해야 합니다.")
+        String password,
+        String validatedPassword
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetPasswordVerifyRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/request/ResetPasswordVerifyRequestDto.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.member.dto.request;
+
+public record ResetPasswordVerifyRequestDto(
+        String name,
+        String email,
+        String birth
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -138,7 +138,6 @@ public class MemberService {
         }
 
         member.update(req.validatedPassword(), passwordEncoder);
-        memberRepository.save(member);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -128,4 +128,17 @@ public class MemberService {
 
         redisUtil.delete(email);
     }
+
+    public void resetNormalMemberPassword(ResetNormalPasswordRequestDto req) {
+        Member member = memberRepository.findByEmail(req.email())
+                .orElseThrow(NotFoundMemberException::new);
+
+        if (!req.password().equals(req.validatedPassword())) {
+            throw new NotMatchedPassword();
+        }
+
+        member.update(req.validatedPassword(), passwordEncoder);
+        memberRepository.save(member);
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -115,4 +115,17 @@ public class MemberService {
         mailService.sendAuthenticationCode(req.email());
     }
 
+    public void verifyAuthCodeForPasswordReset(String email, String code) {
+        String validatedNumber = (String) redisUtil.get(email);
+
+        if (validatedNumber == null || redisUtil.checkExpired(email) <= 0) {
+            throw new ExpiredNumberException();
+        }
+
+        if (!validatedNumber.equals(code)) {
+            throw new NotMatchedNumberException();
+        }
+
+        redisUtil.delete(email);
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -1,9 +1,6 @@
 package com.tave.tavewebsite.domain.member.service;
 
-import com.tave.tavewebsite.domain.member.dto.request.RegisterManagerRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.RegisterMemberRequestDto;
-import com.tave.tavewebsite.domain.member.dto.request.ResetPasswordReq;
-import com.tave.tavewebsite.domain.member.dto.request.ValidateEmailReq;
+import com.tave.tavewebsite.domain.member.dto.request.*;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.exception.DuplicateEmailException;
 import com.tave.tavewebsite.domain.member.exception.DuplicateNicknameException;
@@ -51,7 +48,7 @@ public class MemberService {
     }
 
     public void sendMessage(ValidateEmailReq req, Boolean reset) {
-        if(reset.equals(Boolean.FALSE))
+        if (reset.equals(Boolean.FALSE))
             validateEmail(req.email());
         else
             findIfEmailExists(req.email());
@@ -60,7 +57,7 @@ public class MemberService {
     }
 
     public void verityNumber(ValidateEmailReq req, Boolean reset) {
-        if(reset.equals(Boolean.FALSE))
+        if (reset.equals(Boolean.FALSE))
             validateEmail(req.email());
         else
             findIfEmailExists(req.email());
@@ -105,6 +102,17 @@ public class MemberService {
                     throw new DuplicateEmailException();
                 }
         );
+    }
+
+    public void verifyNormalMemberForPasswordReset(ResetPasswordVerifyRequestDto req) {
+        Member member = memberRepository.findByEmail(req.email())
+                .orElseThrow(NotFoundMemberException::new);
+
+        if (!member.getUsername().equals(req.name()) || !member.getBirthday().toString().equals(req.birth())) {
+            throw new NotFoundMemberException();
+        }
+
+        mailService.sendAuthenticationCode(req.email());
     }
 
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> 86
> Close #86

## 📑 작업 내용
> - 일반 회원 비밀번호 찾기 로직과 비밀번호 재설정 기능 구현
> - 관리자와 다르게 이름, 이메일, 생년월일 입력받음
> - 이메일과 인증 번호 사용해 인증 번호 확인받음
> - 기존 관리자 비밀번호 재설정 로직과 동일한 방식으로 처리

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> API 엔드포인트 맞는지 확인 부탁드립니다
