### PR TITLE
[Feat] 이력서 생성시 프로그래밍 언어 초기화 작업

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageAdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageAdminController.java
@@ -1,0 +1,41 @@
+package com.tave.tavewebsite.domain.programinglaunguage.controller;
+
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.request.ProgramingLanguageRequestDto;
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.ProgrammingLanguageResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.service.ProgramingLanguageAdminService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProgramingLanguageAdminController {
+
+    private final ProgramingLanguageAdminService programingLanguageAdminService;
+
+    @GetMapping("/v1/manager/lan/{field}")
+    public SuccessResponse<List<ProgrammingLanguageResponseDto>> getAllProgrammingLanguageByField(
+            @PathVariable("field") String field) {
+        return new SuccessResponse<>(programingLanguageAdminService.getAllProgramingLanguagesByField(field),
+                ProgramingLanguageSuccessMessage.READ_LANGUAGE_SUCCESS.getMessage());
+    }
+
+    @PostMapping("/v1/manager/lan")
+    public SuccessResponse postProgrammingLanguage(@RequestBody ProgramingLanguageRequestDto requestDto) {
+        programingLanguageAdminService.createProgramingLanguage(requestDto);
+        return SuccessResponse.ok(ProgramingLanguageSuccessMessage.CREATE_LANGUAGE_SUCCESS.getMessage());
+    }
+
+    @DeleteMapping("/v1/manager/lan/{id}")
+    public SuccessResponse deleteProgrammingLanguageById(@PathVariable("id") Long id) {
+        programingLanguageAdminService.deleteProgramingLanguage(id);
+        return SuccessResponse.ok(ProgramingLanguageSuccessMessage.DELETE_LANGUAGE_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageAdminController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageAdminController.java
@@ -12,28 +12,30 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1/manager")
 public class ProgramingLanguageAdminController {
 
     private final ProgramingLanguageAdminService programingLanguageAdminService;
 
-    @GetMapping("/v1/manager/lan/{field}")
+    @GetMapping("/lan/{field}")
     public SuccessResponse<List<ProgrammingLanguageResponseDto>> getAllProgrammingLanguageByField(
             @PathVariable("field") String field) {
         return new SuccessResponse<>(programingLanguageAdminService.getAllProgramingLanguagesByField(field),
                 ProgramingLanguageSuccessMessage.READ_LANGUAGE_SUCCESS.getMessage());
     }
 
-    @PostMapping("/v1/manager/lan")
+    @PostMapping("/lan")
     public SuccessResponse postProgrammingLanguage(@RequestBody ProgramingLanguageRequestDto requestDto) {
         programingLanguageAdminService.createProgramingLanguage(requestDto);
         return SuccessResponse.ok(ProgramingLanguageSuccessMessage.CREATE_LANGUAGE_SUCCESS.getMessage());
     }
 
-    @DeleteMapping("/v1/manager/lan/{id}")
+    @DeleteMapping("/lan/{id}")
     public SuccessResponse deleteProgrammingLanguageById(@PathVariable("id") Long id) {
         programingLanguageAdminService.deleteProgramingLanguage(id);
         return SuccessResponse.ok(ProgramingLanguageSuccessMessage.DELETE_LANGUAGE_SUCCESS.getMessage());

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
@@ -12,22 +12,24 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/v1/member")
 @Validated
 public class ProgramingLanguageController {
 
     private final ProgramingLanguageService programingLanguageService;
 
-    @GetMapping("/v1/member/lan/{id}")
+    @GetMapping("/lan/{id}")
     public SuccessResponse<List<LanguageLevelResponseDto>> getLanguageLevels(@PathVariable("id") Long id) {
         return new SuccessResponse<>(programingLanguageService.getLanguageLevel(id),
                 ProgramingLanguageSuccessMessage.READ_LEVEL_SUCCESS.getMessage());
     }
 
-    @PatchMapping("/v1/member/lan/{id}")
+    @PatchMapping("/lan/{id}")
     public SuccessResponse patchLanguageLevels(@PathVariable("id") Long id,
                                                @RequestBody @Valid List<LanguageLevelRequestDto> languageLevelRequestDtos) {
         programingLanguageService.patchLanguageLevel(id, languageLevelRequestDtos);

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageController.java
@@ -24,7 +24,7 @@ public class ProgramingLanguageController {
     @GetMapping("/v1/member/lan/{id}")
     public SuccessResponse<List<LanguageLevelResponseDto>> getLanguageLevels(@PathVariable("id") Long id) {
         return new SuccessResponse<>(programingLanguageService.getLanguageLevel(id),
-                ProgramingLanguageSuccessMessage.READ_SUCCESS.getMessage());
+                ProgramingLanguageSuccessMessage.READ_LEVEL_SUCCESS.getMessage());
     }
 
     @PatchMapping("/v1/member/lan/{id}")

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/controller/ProgramingLanguageSuccessMessage.java
@@ -5,7 +5,10 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public enum ProgramingLanguageSuccessMessage {
     UPDATE_SUCCESS("레벨 수정에 성공했습니다."),
-    READ_SUCCESS("레벨 조회에 성공했습니다.");
+    READ_LEVEL_SUCCESS("레벨 조회에 성공했습니다."),
+    READ_LANGUAGE_SUCCESS("모든 언어 조회에 성공했습니다."),
+    CREATE_LANGUAGE_SUCCESS("언어 생성에 성공했습니다."),
+    DELETE_LANGUAGE_SUCCESS("언어 삭제에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/ProgramingLanguageRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/ProgramingLanguageRequestDto.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.programinglaunguage.dto.request;
+
+public record ProgramingLanguageRequestDto(
+        String field,
+        String language
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/ProgrammingLanguageByFieldRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/request/ProgrammingLanguageByFieldRequestDto.java
@@ -1,0 +1,6 @@
+package com.tave.tavewebsite.domain.programinglaunguage.dto.request;
+
+public record ProgrammingLanguageByFieldRequestDto(
+        String field
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/response/ProgrammingLanguageResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/dto/response/ProgrammingLanguageResponseDto.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.programinglaunguage.dto.response;
+
+public record ProgrammingLanguageResponseDto(
+        Long id,
+        String field,
+        String language
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/ProgramingLanguage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/entity/ProgramingLanguage.java
@@ -1,8 +1,11 @@
 package com.tave.tavewebsite.domain.programinglaunguage.entity;
 
 import com.tave.tavewebsite.global.common.BaseEntity;
+import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -29,11 +32,11 @@ public class ProgramingLanguage extends BaseEntity {
 
     @NotNull
     @Column(nullable = false)
-    @Size(min = 1, max = 8)
-    private String field;
+    @Enumerated(EnumType.STRING)
+    private FieldType field;
 
     @Builder
-    ProgramingLanguage(String language, String field) {
+    ProgramingLanguage(String language, FieldType field) {
         this.language = language;
         this.field = field;
     }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
@@ -13,8 +13,8 @@ public abstract class LanguageErrorException {
 
     public static class NotFoundFieldException extends BaseErrorException {
         public NotFoundFieldException() {
-            super(ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getCode(),
-                    ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getMessage());
+            super(ProgrammingLanguageErrorMessage.NOT_FOUND_FIELD_LANGUAGE.getCode(),
+                    ProgrammingLanguageErrorMessage.NOT_FOUND_FIELD_LANGUAGE.getMessage());
         }
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.programinglaunguage.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+public abstract class LanguageErrorException {
+
+    public static class NotFoundLanguageException extends BaseErrorException {
+        public NotFoundLanguageException() {
+            super(ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getCode(),
+                    ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/LanguageErrorException.java
@@ -11,4 +11,11 @@ public abstract class LanguageErrorException {
         }
     }
 
+    public static class NotFoundFieldException extends BaseErrorException {
+        public NotFoundFieldException() {
+            super(ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getCode(),
+                    ProgrammingLanguageErrorMessage.NOT_FOUND_PROGRAMMING_LANGUAGE.getMessage());
+        }
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum ProgrammingLanguageErrorMessage {
 
     NOT_FOUND_PROGRAMMING_LANGUAGE(400, "해당 언어를 찾을 수 없습니다."),
-    NOT_FOUND_FIELD_LANGUAGE(400, "해당 분야를 찾을 수 없습니다.");
+    NOT_FOUND_FIELD_LANGUAGE(400, "해당 언어를 찾을 수 없습니다.");
 
 
     final int code;

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum ProgrammingLanguageErrorMessage {
 
     NOT_FOUND_PROGRAMMING_LANGUAGE(400, "해당 언어를 찾을 수 없습니다."),
-    NOT_FOUND_FIELD_LANGUAGE(400, "해당 언어를 찾을 수 없습니다.");
+    NOT_FOUND_FIELD_LANGUAGE(400, "해당 분야를 찾을 수 없습니다.");
 
 
     final int code;

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ProgrammingLanguageErrorMessage {
 
-    NOT_FOUND_PROGRAMMING_LANGUAGE(400, "해당 언어를 찾을 수 없습니다.");
+    NOT_FOUND_PROGRAMMING_LANGUAGE(400, "해당 언어를 찾을 수 없습니다."),
+    NOT_FOUND_FIELD_LANGUAGE(400, "해당 분야를 찾을 수 없습니다.");
+
 
     final int code;
     final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/exception/ProgrammingLanguageErrorMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.programinglaunguage.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ProgrammingLanguageErrorMessage {
+
+    NOT_FOUND_PROGRAMMING_LANGUAGE(400, "해당 언어를 찾을 수 없습니다.");
+
+    final int code;
+    final String message;
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/ProgramingLanguageRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/repository/ProgramingLanguageRepository.java
@@ -1,9 +1,12 @@
 package com.tave.tavewebsite.domain.programinglaunguage.repository;
 
 import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import com.tave.tavewebsite.global.common.FieldType;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProgramingLanguageRepository extends JpaRepository<ProgramingLanguage, Long> {
+    List<ProgramingLanguage> findByField(FieldType field);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageAdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageAdminService.java
@@ -32,7 +32,8 @@ public class ProgramingLanguageAdminService {
 
     @Transactional
     public void deleteProgramingLanguage(Long id) {
-        programingLanguageRepository.findById(id).orElseThrow(LanguageErrorException.NotFoundLanguageException::new);
+        programingLanguageRepository.findById(id)
+                .orElseThrow(LanguageErrorException.NotFoundLanguageException::new);
         programingLanguageRepository.deleteById(id);
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageAdminService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageAdminService.java
@@ -1,0 +1,39 @@
+package com.tave.tavewebsite.domain.programinglaunguage.service;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.request.ProgramingLanguageRequestDto;
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.ProgrammingLanguageResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import com.tave.tavewebsite.domain.programinglaunguage.exception.LanguageErrorException;
+import com.tave.tavewebsite.domain.programinglaunguage.repository.ProgramingLanguageRepository;
+import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ProgramingLanguageAdminService {
+
+    private final ProgramingLanguageRepository programingLanguageRepository;
+
+    public List<ProgrammingLanguageResponseDto> getAllProgramingLanguagesByField(
+            String field) {
+        List<ProgramingLanguage> programingLanguagesByField = programingLanguageRepository.findByField(
+                LanguageLevelMapper.validateAndConvertFieldType(field));
+        return LanguageLevelMapper.toProgrammingLanguageResponseDtoList(programingLanguagesByField);
+    }
+
+    @Transactional
+    public void createProgramingLanguage(ProgramingLanguageRequestDto programingLanguageRequestDto) {
+        programingLanguageRepository.save(LanguageLevelMapper.toProgramingLanguage(programingLanguageRequestDto));
+    }
+
+    @Transactional
+    public void deleteProgramingLanguage(Long id) {
+        programingLanguageRepository.findById(id).orElseThrow(LanguageErrorException.NotFoundLanguageException::new);
+        programingLanguageRepository.deleteById(id);
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/service/ProgramingLanguageService.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.programinglaunguage.service;
 import com.tave.tavewebsite.domain.programinglaunguage.dto.request.LanguageLevelRequestDto;
 import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import com.tave.tavewebsite.domain.programinglaunguage.repository.LanguageLevelRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProgramingLanguageService {
 
     private final ResumeRepository resumeRepository;
+    private final LanguageLevelRepository languageLevelRepository;
 
     public List<LanguageLevelResponseDto> getLanguageLevel(Long resumeId) {
         Resume resume = resumeRepository.findResumeWithLanguageLevels(resumeId);

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
@@ -5,8 +5,8 @@ import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLeve
 import com.tave.tavewebsite.domain.programinglaunguage.dto.response.ProgrammingLanguageResponseDto;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import com.tave.tavewebsite.domain.programinglaunguage.exception.LanguageErrorException.NotFoundFieldException;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
-import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
 import com.tave.tavewebsite.global.common.FieldType;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,7 +49,7 @@ public class LanguageLevelMapper {
         try {
             return FieldType.valueOf(field.toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new ResumeNotFoundException();
+            throw new NotFoundFieldException();
         }
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/programinglaunguage/util/LanguageLevelMapper.java
@@ -1,11 +1,55 @@
 package com.tave.tavewebsite.domain.programinglaunguage.util;
 
+import com.tave.tavewebsite.domain.programinglaunguage.dto.request.ProgramingLanguageRequestDto;
 import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.ProgrammingLanguageResponseDto;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
+import com.tave.tavewebsite.global.common.FieldType;
+import java.util.ArrayList;
+import java.util.List;
 
 public class LanguageLevelMapper {
 
     public static LanguageLevelResponseDto toLanguageLevelResponseDto(LanguageLevel languageLevel) {
         return new LanguageLevelResponseDto(languageLevel.getLanguage(), languageLevel.getLevel());
+    }
+
+    public static List<LanguageLevel> toLanguageLevel(List<ProgramingLanguage> programingLanguages, Resume resume) {
+        List<LanguageLevel> languageLevels = new ArrayList<>();
+        for (ProgramingLanguage programingLanguage : programingLanguages) {
+            languageLevels.add(
+                    LanguageLevel.builder().language(programingLanguage.getLanguage()).resume(resume).build());
+        }
+
+        return languageLevels;
+    }
+
+    public static ProgramingLanguage toProgramingLanguage(ProgramingLanguageRequestDto programingLanguageRequestDto) {
+        FieldType fieldType = validateAndConvertFieldType(programingLanguageRequestDto.field());
+        return ProgramingLanguage.builder().field(fieldType).language(
+                programingLanguageRequestDto.language()).build();
+    }
+
+    public static List<ProgrammingLanguageResponseDto> toProgrammingLanguageResponseDtoList(
+            List<ProgramingLanguage> programingLanguages) {
+        List<ProgrammingLanguageResponseDto> programmingLanguageResponseDtoList = new ArrayList<>();
+        for (ProgramingLanguage programingLanguage : programingLanguages) {
+            programmingLanguageResponseDtoList.add(
+                    new ProgrammingLanguageResponseDto(programingLanguage.getId(), programingLanguage.getField().name(),
+                            programingLanguage.getLanguage())
+            );
+        }
+        return programmingLanguageResponseDtoList;
+    }
+
+    public static FieldType validateAndConvertFieldType(String field) {
+        try {
+            return FieldType.valueOf(field.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new ResumeNotFoundException();
+        }
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -40,8 +40,8 @@ public class PersonalInfoService {
 
         // 필드값 기준으로 질문들을 찾은 후 해당 질문들을 모두 저장시키는 과정
         List<ProgramingLanguage> byField = programingLanguageRepository.findByField(
-                FieldType.valueOf(savedResume.getField())); // *****지우야**** 여기 지금 String으로 돼있어서 내가 강제러 바꿔놧는데
-        // field 타입 바꾸고 나서 여기 코드도 수정해줘
+                FieldType.valueOf(
+                        savedResume.getField())); //todo *****지우야**** 여기 지금 resume field가 String으로 돼있어서 내가 강제로 바꿔놨는데 field 타입 바꾸고 나서 여기 코드도 수정해줘
         List<LanguageLevel> languageLevel = LanguageLevelMapper.toLanguageLevel(byField, savedResume);
 
         languageLevelRepository.saveAll(languageLevel);

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -2,6 +2,11 @@ package com.tave.tavewebsite.domain.resume.service;
 
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
+import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage;
+import com.tave.tavewebsite.domain.programinglaunguage.repository.LanguageLevelRepository;
+import com.tave.tavewebsite.domain.programinglaunguage.repository.ProgramingLanguageRepository;
+import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
@@ -9,7 +14,9 @@ import com.tave.tavewebsite.domain.resume.exception.MemberNotFoundException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
 import com.tave.tavewebsite.domain.resume.mapper.ResumeMapper;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +25,8 @@ import org.springframework.stereotype.Service;
 public class PersonalInfoService {
     private final ResumeRepository resumeRepository;
     private final MemberRepository memberRepository;
+    private final ProgramingLanguageRepository programingLanguageRepository;
+    private final LanguageLevelRepository languageLevelRepository;
 
     // 개인정보 저장
     @Transactional
@@ -27,12 +36,15 @@ public class PersonalInfoService {
 
         // 지원 분야 값 검증 및 변환
         Resume.FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
+        Resume savedResume = resumeRepository.save(ResumeMapper.toResume(requestDto, member));
 
-        Resume resume = ResumeMapper.toResume(requestDto, member);
-        resumeRepository.save(resume);
+        // 필드값 기준으로 질문들을 찾은 후 해당 질문들을 모두 저장시키는 과정
+        List<ProgramingLanguage> byField = programingLanguageRepository.findByField(
+                FieldType.valueOf(savedResume.getField())); // *****지우야**** 여기 지금 String으로 돼있어서 내가 강제러 바꿔놧는데
+        // field 타입 바꾸고 나서 여기 코드도 수정해줘
+        List<LanguageLevel> languageLevel = LanguageLevelMapper.toLanguageLevel(byField, savedResume);
 
-        resume.updatePersonalInfo(requestDto);
-        resumeRepository.save(resume);
+        languageLevelRepository.saveAll(languageLevel);
     }
 
     // 임시 저장 기능 (현재까지 입력한 정보 저장)

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -9,6 +9,7 @@ public enum FieldType {
     DESIGN("Design"),
     DEEPLEARNING("Deep Learning"),
     DATAANALYSIS("Data Analysis"),
+    FRONTEND("Frontend"),
     WEBFRONTEND("Web Frontend"),
     APPFRONTEND("App Frontend"),
     BACKEND("Backend"),

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -9,7 +9,8 @@ public enum FieldType {
     DESIGN("Design"),
     DEEPLEARNING("Deep Learning"),
     DATAANALYSIS("Data Analysis"),
-    FRONTEND("Frontend"),
+    WEBFRONTEND("Web Frontend"),
+    APPFRONTEND("App Frontend"),
     BACKEND("Backend"),
     ADVANCED("Advanced"),       // 심화
     COMMON("Common"),


### PR DESCRIPTION
## ➕ 연관된 이슈
> #110 
> Close #110 

## 📑 작업 내용
> - 1. 관리자는 다음의 post 요청으로 field 별 질문할 언어의 종류를 설정할 수 있습니다.
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/ac5f350e-90c5-4129-ba7d-bbaf07f639b5" />

> - 2. 생성된 언어는 이력서 생성시 이력서의 필드 값을 기준으로 조회됩니다.
<img width="1045" alt="image" src="https://github.com/user-attachments/assets/9f446ca4-4315-47cd-950b-d8977a1305df" />

(예를 들어 이력서의 필드값이 백엔드라면, 백엔드에 저장된 언어들이 조회되는 로직입니다.)

> - 3. 조회된 언어들은 saveAll 메서드를 통해 이력서와 연관관계를 가지며 모두 저장됩니다.

> - 4. 주의사항 (field의 이름이 다르다면 조회에 실패하니 field이름에 대한 예외 처리가 잘 이뤄져야 합니다.)

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
