### PR TITLE
[Bug] Resume 삭제 시 FK 제약 오류 발생

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -19,18 +19,6 @@ public class PersonalInfoController {
 
     private final PersonalInfoService personalInfoService;
 
-    // 개인정보 저장 및 질문 목록 반환
-    @PostMapping("/resume/{memberId}")
-    public SuccessResponse<CreatePersonalInfoResponse> createPersonalInfoWithQuestions(@PathVariable("memberId") Long memberId,
-                                                                                       @RequestBody @Valid PersonalInfoRequestDto requestDto) {
-        ResumeQuestionResponse questions = personalInfoService.createPersonalInfo(memberId, requestDto);
-
-        CreatePersonalInfoResponse response = CreatePersonalInfoResponse.of(
-                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(), questions);
-
-        return new SuccessResponse<>(response, PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
-    }
-
     // 개인정보 저장 (새로운 지원서 생성)
     @PostMapping("/{memberId}")
     public SuccessResponse createPersonalInfo(@PathVariable("memberId") Long memberId,

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -1,9 +1,8 @@
 package com.tave.tavewebsite.domain.resume.controller;
 
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
-import com.tave.tavewebsite.domain.resume.dto.response.CreatePersonalInfoResponse;
+import com.tave.tavewebsite.domain.resume.dto.request.TempPersonalInfoDto;
 import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
-import com.tave.tavewebsite.domain.resume.dto.response.ResumeQuestionResponse;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
@@ -11,10 +10,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessMessage.*;
+
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/v1/member/info")
+@RequestMapping("/v1/normal/info")
 public class PersonalInfoController {
 
     private final PersonalInfoService personalInfoService;
@@ -24,14 +25,14 @@ public class PersonalInfoController {
     public SuccessResponse createPersonalInfo(@PathVariable("memberId") Long memberId,
                                               @RequestBody @Valid PersonalInfoRequestDto requestDto) {
         personalInfoService.createPersonalInfo(memberId, requestDto);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
+        return SuccessResponse.ok(CREATE_SUCCESS.getMessage());
     }
 
     // 개인정보 조회
     @GetMapping("/{resumeId}")
     public SuccessResponse<PersonalInfoResponseDto> getPersonalInfo(@PathVariable("resumeId") Long resumeId) {
         return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
-                PersonalInfoSuccessMessage.READ_SUCCESS.getMessage());
+                READ_SUCCESS.getMessage());
     }
 
     // 개인정보 수정
@@ -39,21 +40,29 @@ public class PersonalInfoController {
     public SuccessResponse updatePersonalInfo(@PathVariable("resumeId") Long resumeId,
                                               @RequestBody @Valid PersonalInfoRequestDto requestDto) {
         personalInfoService.updatePersonalInfo(resumeId, requestDto);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.UPDATE_SUCCESS.getMessage());
+        return SuccessResponse.ok(UPDATE_SUCCESS.getMessage());
     }
 
     // 개인정보 삭제
     @DeleteMapping("/{resumeId}")
     public SuccessResponse deletePersonalInfo(@PathVariable("resumeId") Long resumeId) {
         personalInfoService.deletePersonalInfo(resumeId);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.DELETE_SUCCESS.getMessage());
+        return SuccessResponse.ok(DELETE_SUCCESS.getMessage());
     }
 
-    // 임시 저장
+    // 개인정보 임시 저장
     @PostMapping("/temp-save/{memberId}")
     public SuccessResponse tempSavePersonalInfo(@PathVariable("memberId") Long memberId,
                                                 @RequestBody @Valid PersonalInfoRequestDto requestDto) {
         personalInfoService.tempSavePersonalInfo(memberId, requestDto);
-        return SuccessResponse.ok(PersonalInfoSuccessMessage.TEMP_SAVE_SUCCESS.getMessage());
+        return SuccessResponse.ok(TEMP_SAVE_SUCCESS.getMessage());
     }
+
+    // 임시 저장 개인정보 불러오기
+    @GetMapping("/temp-save/{memberId}")
+    public SuccessResponse<TempPersonalInfoDto> getTempSavedPersonalInfo(@PathVariable("memberId") Long memberId) {
+        TempPersonalInfoDto response = personalInfoService.getTempSavedPersonalInfo(memberId);
+        return new SuccessResponse<>(response, TEMP_LOAD_SUCCESS.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
@@ -8,7 +8,8 @@ public enum PersonalInfoSuccessMessage {
     UPDATE_SUCCESS("개인정보 수정에 성공했습니다."),
     READ_SUCCESS("개인정보 조회에 성공했습니다."),
     DELETE_SUCCESS("개인정보 삭제에 성공했습니다."),
-    TEMP_SAVE_SUCCESS("임시 저장에 성공했습니다.");
+    TEMP_SAVE_SUCCESS("임시 저장에 성공했습니다."),
+    QUESTION_READ_SUCCESS("질문과 답변 조회에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
@@ -8,8 +8,9 @@ public enum PersonalInfoSuccessMessage {
     UPDATE_SUCCESS("개인정보 수정에 성공했습니다."),
     READ_SUCCESS("개인정보 조회에 성공했습니다."),
     DELETE_SUCCESS("개인정보 삭제에 성공했습니다."),
+    QUESTION_READ_SUCCESS("질문과 답변 조회에 성공했습니다."),
     TEMP_SAVE_SUCCESS("임시 저장에 성공했습니다."),
-    QUESTION_READ_SUCCESS("질문과 답변 조회에 성공했습니다.");
+    TEMP_LOAD_SUCCESS("임시 저장 조회에 성공했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeAnswerTempController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeAnswerTempController.java
@@ -1,0 +1,37 @@
+package com.tave.tavewebsite.domain.resume.controller;
+
+import com.tave.tavewebsite.domain.resume.dto.request.ResumeAnswerTempDto;
+import com.tave.tavewebsite.domain.resume.service.ResumeAnswerTempService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessMessage.TEMP_LOAD_SUCCESS;
+import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessMessage.TEMP_SAVE_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/normal/resume/temp-answer")
+public class ResumeAnswerTempController {
+
+    private final ResumeAnswerTempService tempService;
+
+    // 임시 저장
+    @PostMapping("/{resumeId}")
+    public SuccessResponse saveTempAnswers(@PathVariable Long resumeId,
+                                           @RequestParam int page,
+                                           @RequestBody List<ResumeAnswerTempDto> answers) {
+        tempService.tempSaveAnswers(resumeId, page, answers);
+        return SuccessResponse.ok(TEMP_SAVE_SUCCESS.getMessage());
+    }
+
+    // 임시 저장 불러오기
+    @GetMapping("/{resumeId}")
+    public SuccessResponse<List<ResumeAnswerTempDto>> getTempAnswers(@PathVariable Long resumeId,
+                                                                     @RequestParam int page) {
+        List<ResumeAnswerTempDto> response = tempService.getTempSavedAnswers(resumeId, page);
+        return new SuccessResponse<>(response, TEMP_LOAD_SUCCESS.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
@@ -4,10 +4,13 @@ import com.tave.tavewebsite.domain.resume.dto.response.DetailResumeQuestionRespo
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.domain.resume.service.ResumeQuestionService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessMessage.QUESTION_READ_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,11 +20,12 @@ public class ResumeQuestionController {
     private final PersonalInfoService personalInfoService;
 
     @GetMapping("/{resumeId}/questions")
-    public List<DetailResumeQuestionResponse> getResumeQuestionsByPage(
+    public SuccessResponse<List<DetailResumeQuestionResponse>> getResumeQuestionsByPage(
             @PathVariable Long resumeId,
             @RequestParam int page
     ) {
         Resume resume = personalInfoService.getResumeEntityById(resumeId);
-        return resumeQuestionService.getResumeQuestionPage(resume, page);
+        List<DetailResumeQuestionResponse> response = resumeQuestionService.getResumeQuestionPage(resume, page);
+        return new SuccessResponse<>(response, QUESTION_READ_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
@@ -1,0 +1,27 @@
+package com.tave.tavewebsite.domain.resume.controller;
+
+import com.tave.tavewebsite.domain.resume.dto.response.DetailResumeQuestionResponse;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
+import com.tave.tavewebsite.domain.resume.service.ResumeQuestionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/member/resumes")
+public class ResumeQuestionController {
+    private final ResumeQuestionService resumeQuestionService;
+    private final PersonalInfoService personalInfoService;
+
+    @GetMapping("/{resumeId}/questions")
+    public List<DetailResumeQuestionResponse> getResumeQuestionsByPage(
+            @PathVariable Long resumeId,
+            @RequestParam int page
+    ) {
+        Resume resume = personalInfoService.getResumeEntityById(resumeId);
+        return resumeQuestionService.getResumeQuestionPage(resume, page);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/ResumeAnswerTempDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/ResumeAnswerTempDto.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.resume.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResumeAnswerTempDto {
+    private Long resumeQuestionId;
+    private String answer;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/TempPersonalInfoDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/request/TempPersonalInfoDto.java
@@ -1,0 +1,17 @@
+package com.tave.tavewebsite.domain.resume.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TempPersonalInfoDto {
+    private String school;
+    private String major;
+    private String minor;
+    private String field;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -76,6 +76,9 @@ public class Resume {
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
     private List<LanguageLevel> languageLevels = new ArrayList<>();
 
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ResumeQuestion> resumeQuestions = new ArrayList<>();
+
     @Builder
     public Resume(String school, String major, String minor, Integer resumeGeneration, String blogUrl, String githubUrl,
                   String portfolioUrl, String state, FieldType field, Member member) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -17,7 +17,9 @@ public enum ErrorMessage {
 
     SOCIAL_LINK_NOT_FOUND(404, "url이 존재하지 않습니다."),
 
-    FIELD_TYPE_INVALID(400, "유효하지 않은 필드 타입입니다.");
+    FIELD_TYPE_INVALID(400, "유효하지 않은 필드 타입입니다."),
+
+    INVALID_PAGE_NUMBER(400, "유효하지 않은 페이지 번호입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -19,7 +19,13 @@ public enum ErrorMessage {
 
     FIELD_TYPE_INVALID(400, "유효하지 않은 필드 타입입니다."),
 
-    INVALID_PAGE_NUMBER(400, "유효하지 않은 페이지 번호입니다.");
+    INVALID_PAGE_NUMBER(400, "유효하지 않은 페이지 번호입니다."),
+
+    // Redis 임시 저장
+    TEMP_NOT_FOUND(404, "임시 저장된 정보가 없습니다."),
+    TEMP_PARSE_FAILED(500, "임시 정보를 파싱하는 데 실패했습니다."),
+    TEMP_SERIALIZE_FAILED(500, "임시 저장 데이터를 JSON으로 변환하는 데 실패했습니다."),
+    TEMP_SAVE_FAILED(500, "임시 저장에 실패했습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidPageNumberException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidPageNumberException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.INVALID_PAGE_NUMBER;
+
+public class InvalidPageNumberException extends BaseErrorException {
+    public InvalidPageNumberException() {
+        super(INVALID_PAGE_NUMBER.getCode(), INVALID_PAGE_NUMBER.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.TEMP_NOT_FOUND;
+
+public class TempNotFoundException extends BaseErrorException {
+    public TempNotFoundException() {
+        super(TEMP_NOT_FOUND.getCode(), TEMP_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempParseFailedException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempParseFailedException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.TEMP_PARSE_FAILED;
+
+public class TempParseFailedException extends BaseErrorException {
+    public TempParseFailedException() {
+        super(TEMP_PARSE_FAILED.getCode(), TEMP_PARSE_FAILED.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempSaveFailedException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempSaveFailedException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.TEMP_SAVE_FAILED;
+
+public class TempSaveFailedException extends BaseErrorException {
+    public TempSaveFailedException() {
+        super(TEMP_SAVE_FAILED.getCode(), TEMP_SAVE_FAILED.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempSerializeFailedException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/TempSerializeFailedException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.TEMP_SERIALIZE_FAILED;
+
+public class TempSerializeFailedException extends BaseErrorException {
+    public TempSerializeFailedException() {
+        super(TEMP_SERIALIZE_FAILED.getCode(), TEMP_SERIALIZE_FAILED.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -31,10 +31,9 @@ public class PersonalInfoService {
     private final MemberRepository memberRepository;
     private final ProgramingLanguageRepository programingLanguageRepository;
     private final LanguageLevelRepository languageLevelRepository;
-    private final ResumeQuestionService resumeQuestionService;
 
     @Transactional
-    public ResumeQuestionResponse createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
+    public void createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
@@ -44,8 +43,6 @@ public class PersonalInfoService {
         List<ProgramingLanguage> byField = programingLanguageRepository.findByField(savedResume.getField());
         List<LanguageLevel> languageLevels = LanguageLevelMapper.toLanguageLevel(byField, savedResume);
         languageLevelRepository.saveAll(languageLevels);
-
-        return resumeQuestionService.createResumeQuestion(savedResume, fieldType);
     }
 
     // 임시 저장 기능 (현재까지 입력한 정보 저장)

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -90,4 +90,10 @@ public class PersonalInfoService {
             throw new FieldTypeInvalidException();
         }
     }
+
+    public Resume getResumeEntityById(Long resumeId) {
+        return resumeRepository.findById(resumeId)
+                .orElseThrow(ResumeNotFoundException::new);
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.resume.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
@@ -8,15 +9,14 @@ import com.tave.tavewebsite.domain.programinglaunguage.repository.LanguageLevelR
 import com.tave.tavewebsite.domain.programinglaunguage.repository.ProgramingLanguageRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.request.TempPersonalInfoDto;
 import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
-import com.tave.tavewebsite.domain.resume.dto.response.ResumeQuestionResponse;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
-import com.tave.tavewebsite.domain.resume.exception.FieldTypeInvalidException;
-import com.tave.tavewebsite.domain.resume.exception.MemberNotFoundException;
-import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
+import com.tave.tavewebsite.domain.resume.exception.*;
 import com.tave.tavewebsite.domain.resume.mapper.ResumeMapper;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import com.tave.tavewebsite.global.common.FieldType;
+import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import jakarta.transaction.Transactional;
 
 import java.util.List;
@@ -31,6 +31,9 @@ public class PersonalInfoService {
     private final MemberRepository memberRepository;
     private final ProgramingLanguageRepository programingLanguageRepository;
     private final LanguageLevelRepository languageLevelRepository;
+
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public void createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
@@ -48,12 +51,35 @@ public class PersonalInfoService {
     // 임시 저장 기능 (현재까지 입력한 정보 저장)
     @Transactional
     public void tempSavePersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
-        Resume resume = resumeRepository.findByMemberId(memberId)
-                .orElseThrow(ResumeNotFoundException::new);
+        TempPersonalInfoDto tempDto = new TempPersonalInfoDto(
+                requestDto.getSchool(),
+                requestDto.getMajor(),
+                requestDto.getMinor(),
+                requestDto.getField()
+        );
 
-        FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
-        // 기존 정보 갱신 (임시 저장 위해)
-        resume.updatePersonalInfo(requestDto, fieldType);
+        try {
+            String json = objectMapper.writeValueAsString(tempDto);
+            String key = "temp-resume:" + memberId;
+            redisUtil.set(key, json, 60 * 24 * 30);
+        } catch (Exception e) {
+            throw new TempSerializeFailedException();
+        }
+    }
+
+    // Redis에서 임시저장 불러오기
+    public TempPersonalInfoDto getTempSavedPersonalInfo(Long memberId) {
+        String key = "temp-resume:" + memberId;
+        Object data = redisUtil.get(key);
+        if (data == null) {
+            throw new TempNotFoundException();
+        }
+
+        try {
+            return objectMapper.readValue(data.toString(), TempPersonalInfoDto.class);
+        } catch (Exception e) {
+            throw new TempParseFailedException();
+        }
     }
 
     public PersonalInfoResponseDto getPersonalInfo(Long resumeId) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
@@ -1,0 +1,46 @@
+package com.tave.tavewebsite.domain.resume.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tave.tavewebsite.domain.resume.dto.request.ResumeAnswerTempDto;
+import com.tave.tavewebsite.domain.resume.exception.TempParseFailedException;
+import com.tave.tavewebsite.domain.resume.exception.TempNotFoundException;
+import com.tave.tavewebsite.domain.resume.exception.TempSaveFailedException;
+import com.tave.tavewebsite.global.redis.utils.RedisUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeAnswerTempService {
+    private final RedisUtil redisUtil;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public void tempSaveAnswers(Long resumeId, int page, List<ResumeAnswerTempDto> answers) {
+        try {
+            String json = objectMapper.writeValueAsString(answers);
+            String key = "temp-resume-answer:" + resumeId + ":" + page;
+            redisUtil.set(key, json, 60 * 24 * 30); // 30일 유효
+        } catch (Exception e) {
+            throw new TempSaveFailedException();
+        }
+    }
+
+    public List<ResumeAnswerTempDto> getTempSavedAnswers(Long resumeId, int page) {
+        String key = "temp-resume-answer:" + resumeId + ":" + page;
+        Object data = redisUtil.get(key);
+        if (data == null) {
+            throw new TempNotFoundException();
+        }
+
+        try {
+            return objectMapper.readValue(data.toString(), new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new TempParseFailedException();
+        }
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -6,6 +6,7 @@ import com.tave.tavewebsite.domain.resume.dto.response.DetailResumeQuestionRespo
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeQuestionResponse;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.entity.ResumeQuestion;
+import com.tave.tavewebsite.domain.resume.exception.InvalidPageNumberException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeQuestionNotMatchResumeException;
 import com.tave.tavewebsite.domain.resume.repository.ResumeQuestionJdbcRepository;
 import com.tave.tavewebsite.domain.resume.repository.ResumeQuestionRepository;
@@ -95,4 +96,20 @@ public class ResumeQuestionService {
         return Stream.concat(commonQuestionList.stream(), specificQuestionList.stream())
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public List<DetailResumeQuestionResponse> getResumeQuestionPage(Resume resume, int page) {
+        FieldType targetFieldType;
+
+        if (page == 1) {
+            targetFieldType = resume.getField(); // 사용자가 지원한 분야
+        } else if (page == 2) {
+            targetFieldType = FieldType.COMMON; // 공통
+        } else {
+            throw new InvalidPageNumberException();
+        }
+
+        return getResumeQuestionList(resume, targetFieldType);
+    }
+
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #126
> Close #126

## 📑 작업 내용
> - 기존에 ResumeQuestion과 Resume 간 매핑이 없어 Resume 삭제 시 외래키 제약 조건 위반 발생
> - Resume 삭제 시 연결된 ResumeQuestion도 함께 삭제되도록 수정
> - Member 삭제 시 Resume 및 해당 Resume에 연결된 ResumeQuestion도 같이 삭제되도록 cascade 및 orphanRemoval 설정 추가
> - @OneToMany 연관관계에서 자식 엔티티가 부모에 종속될 경우 cascade와 orphanRemoval 설정 필요, 없으면 삭제 순서 문제로 오류 발생 가능

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
