### PR TITLE
[Bug] Resume 삭제 시 FK 제약 오류 발생

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Member.java
@@ -85,7 +85,7 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Sex sex;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Resume> resumes = new ArrayList<>();
 
     // 패스워드 인코딩 필요

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -76,6 +76,9 @@ public class Resume {
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
     private List<LanguageLevel> languageLevels = new ArrayList<>();
 
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ResumeQuestion> resumeQuestions = new ArrayList<>();
+
     @Builder
     public Resume(String school, String major, String minor, Integer resumeGeneration, String blogUrl, String githubUrl,
                   String portfolioUrl, String state, FieldType field, Member member) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -70,10 +70,10 @@ public class Resume {
     @JoinColumn(name = "memberId", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TimeSlot> timeSlots = new ArrayList<>();
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<LanguageLevel> languageLevels = new ArrayList<>();
 
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
## ➕ 연관된 이슈
> #126
> Close #126

## 📑 작업 내용
> - 기존에 ResumeQuestion과 Resume 간 매핑이 없어 Resume 삭제 시 외래키 제약 조건 위반 발생
> - Resume 삭제 시 연결된 ResumeQuestion도 함께 삭제되도록 수정
> - Member 삭제 시 Resume 및 해당 Resume에 연결된 ResumeQuestion도 같이 삭제되도록 cascade 및 orphanRemoval 설정 추가
> - @oneTomany 연관관계에서 자식 엔티티가 부모에 종속될 경우 cascade와 orphanRemoval 설정 필요, 없으면 삭제 순서 문제로 오류 발생 가능

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
