### PR TITLE
Feat 면접 설정 api 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.interviewfinal.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    INTERVIEW_PLACE_GET("면접 장소 정보를 조회합니다"),
+    INTERVIEW_PLACE_CREATED("면접 장소 정보를 성공적으로 생성했습니다.");
+
+
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
@@ -1,0 +1,29 @@
+package com.tave.tavewebsite.domain.interviewplace.controller;
+
+import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSaveDto;
+import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceResponse;
+import com.tave.tavewebsite.domain.interviewplace.service.InterviewPlaceService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.*;
+
+@RestController
+@RequiredArgsConstructor
+public class InterviewPlaceController {
+
+    private final InterviewPlaceService interviewPlaceService;
+
+    @PostMapping("/v1/manager/interview-place")
+    public SuccessResponse<InterviewPlaceResponse> saveInterviewPlace(@RequestBody InterviewPlaceSaveDto dto) {
+
+        InterviewPlaceResponse response = interviewPlaceService.saveInterviewPlace(dto);
+
+        return new SuccessResponse<>(response, INTERVIEW_PLACE_CREATED.getMessage());
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSave
 import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceResponse;
 import com.tave.tavewebsite.domain.interviewplace.service.InterviewPlaceService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,7 +20,7 @@ public class InterviewPlaceController {
     private final InterviewPlaceService interviewPlaceService;
 
     @PostMapping("/v1/manager/interview-place")
-    public SuccessResponse<InterviewPlaceResponse> saveInterviewPlace(@RequestBody InterviewPlaceSaveDto dto) {
+    public SuccessResponse<InterviewPlaceResponse> saveInterviewPlace(@RequestBody @Valid InterviewPlaceSaveDto dto) {
 
         InterviewPlaceResponse response = interviewPlaceService.saveInterviewPlace(dto);
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
@@ -26,4 +26,12 @@ public class InterviewPlaceController {
         return new SuccessResponse<>(response, INTERVIEW_PLACE_CREATED.getMessage());
     }
 
+    @GetMapping("/v1/manager/interview-place")
+    public SuccessResponse<InterviewPlaceResponse> getInterviewPlace() {
+
+        InterviewPlaceResponse response = interviewPlaceService.getInterviewPlace();
+
+        return new SuccessResponse<>(response, INTERVIEW_PLACE_GET.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
@@ -1,17 +1,19 @@
 package com.tave.tavewebsite.domain.interviewplace.dto.request;
 
 
+import jakarta.validation.constraints.NotBlank;
+
 public record InterviewPlaceSaveDto(
 
-        String generalAddress,
-        String detailAddress,
-        String firstOpenChatLink,
-        String secondOpenChatLink,
-        String thirdOpenChatLink,
-        String fourthOpenChatLink,
-        String firstDocumentLink,
-        String secondDocumentLink,
-        String thirdDocumentLink,
-        String fourthDocumentLink
+        @NotBlank String generalAddress,
+        @NotBlank String detailAddress,
+        @NotBlank String firstOpenChatLink,
+        @NotBlank String secondOpenChatLink,
+        @NotBlank String thirdOpenChatLink,
+        @NotBlank String fourthOpenChatLink,
+        @NotBlank String firstDocumentLink,
+        @NotBlank String secondDocumentLink,
+        @NotBlank String thirdDocumentLink,
+        @NotBlank String fourthDocumentLink
 ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
@@ -1,0 +1,17 @@
+package com.tave.tavewebsite.domain.interviewplace.dto.request;
+
+
+public record InterviewPlaceSaveDto(
+
+        String generalAddress,
+        String detailAddress,
+        String firstOpenChatLink,
+        String secondOpenChatLink,
+        String thirdOpenChatLink,
+        String fourthOpenChatLink,
+        String firstDocumentLink,
+        String secondDocumentLink,
+        String thridDocumentLink,
+        String fourthDocumentLink
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/request/InterviewPlaceSaveDto.java
@@ -11,7 +11,7 @@ public record InterviewPlaceSaveDto(
         String fourthOpenChatLink,
         String firstDocumentLink,
         String secondDocumentLink,
-        String thridDocumentLink,
+        String thirdDocumentLink,
         String fourthDocumentLink
 ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
@@ -28,7 +28,7 @@ public record InterviewPlaceResponse(
                 .fourthOpenChatLink(interviewPlace.getFourthOpenChatLink())
                 .firstDocumentLink(interviewPlace.getFirstDocumentLink())
                 .secondDocumentLink(interviewPlace.getSecondDocumentLink())
-                .thirdDocumentLink(interviewPlace.getThridDocumentLink())
+                .thirdDocumentLink(interviewPlace.getThirdDocumentLink())
                 .fourthDocumentLink(interviewPlace.getFourthDocumentLink())
                 .build();
     }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
@@ -14,7 +14,7 @@ public record InterviewPlaceResponse(
         String fourthOpenChatLink,
         String firstDocumentLink,
         String secondDocumentLink,
-        String thridDocumentLink,
+        String thirdDocumentLink,
         String fourthDocumentLink
 ) {
     public static InterviewPlaceResponse of(InterviewPlace interviewPlace) {
@@ -28,7 +28,7 @@ public record InterviewPlaceResponse(
                 .fourthOpenChatLink(interviewPlace.getFourthOpenChatLink())
                 .firstDocumentLink(interviewPlace.getFirstDocumentLink())
                 .secondDocumentLink(interviewPlace.getSecondDocumentLink())
-                .thridDocumentLink(interviewPlace.getThridDocumentLink())
+                .thirdDocumentLink(interviewPlace.getThridDocumentLink())
                 .fourthDocumentLink(interviewPlace.getFourthDocumentLink())
                 .build();
     }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/dto/response/InterviewPlaceResponse.java
@@ -1,0 +1,35 @@
+package com.tave.tavewebsite.domain.interviewplace.dto.response;
+
+import com.tave.tavewebsite.domain.interviewplace.entity.InterviewPlace;
+import lombok.Builder;
+
+@Builder
+public record InterviewPlaceResponse(
+        Long id,
+        String generalAddress,
+        String detailAddress,
+        String firstOpenChatLink,
+        String secondOpenChatLink,
+        String thirdOpenChatLink,
+        String fourthOpenChatLink,
+        String firstDocumentLink,
+        String secondDocumentLink,
+        String thridDocumentLink,
+        String fourthDocumentLink
+) {
+    public static InterviewPlaceResponse of(InterviewPlace interviewPlace) {
+        return InterviewPlaceResponse.builder()
+                .id(interviewPlace.getId())
+                .generalAddress(interviewPlace.getGeneralAddress())
+                .detailAddress(interviewPlace.getDetailAddress())
+                .firstOpenChatLink(interviewPlace.getFirstOpenChatLink())
+                .secondOpenChatLink(interviewPlace.getSecondOpenChatLink())
+                .thirdOpenChatLink(interviewPlace.getThirdOpenChatLink())
+                .fourthOpenChatLink(interviewPlace.getFourthOpenChatLink())
+                .firstDocumentLink(interviewPlace.getFirstDocumentLink())
+                .secondDocumentLink(interviewPlace.getSecondDocumentLink())
+                .thridDocumentLink(interviewPlace.getThridDocumentLink())
+                .fourthDocumentLink(interviewPlace.getFourthDocumentLink())
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
@@ -42,7 +42,7 @@ public class InterviewPlace extends BaseEntity {
     public String secondDocumentLink;
 
     @Column(columnDefinition = "TEXT")
-    public String thridDocumentLink;
+    public String thirdDocumentLink;
 
     @Column(columnDefinition = "TEXT")
     public String fourthDocumentLink;
@@ -57,7 +57,7 @@ public class InterviewPlace extends BaseEntity {
                 .fourthOpenChatLink(dto.fourthOpenChatLink())
                 .firstDocumentLink(dto.firstDocumentLink())
                 .secondDocumentLink(dto.secondDocumentLink())
-                .thridDocumentLink(dto.thridDocumentLink())
+                .thirdDocumentLink(dto.thirdDocumentLink())
                 .fourthDocumentLink(dto.fourthDocumentLink())
                 .build();
     }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
@@ -1,0 +1,65 @@
+package com.tave.tavewebsite.domain.interviewplace.entity;
+
+import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSaveDto;
+import com.tave.tavewebsite.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewPlace extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    public String generalAddress;
+
+    public String detailAddress;
+
+    // HACK 면접 기간을 나흘로 하드 코딩
+    @Column(columnDefinition = "TEXT")
+    public String firstOpenChatLink;
+
+    @Column(columnDefinition = "TEXT")
+    public String secondOpenChatLink;
+
+    @Column(columnDefinition = "TEXT")
+    public String thirdOpenChatLink;
+
+    @Column(columnDefinition = "TEXT")
+    public String fourthOpenChatLink;
+
+    @Column(columnDefinition = "TEXTX")
+    public String firstDocumentLink;
+
+    @Column(columnDefinition = "TEXTX")
+    public String secondDocumentLink;
+
+    @Column(columnDefinition = "TEXTX")
+    public String thridDocumentLink;
+
+    @Column(columnDefinition = "TEXTX")
+    public String fourthDocumentLink;
+
+    public static InterviewPlace of(InterviewPlaceSaveDto dto) {
+        return InterviewPlace.builder()
+                .generalAddress(dto.generalAddress())
+                .detailAddress(dto.detailAddress())
+                .firstOpenChatLink(dto.firstOpenChatLink())
+                .secondOpenChatLink(dto.secondOpenChatLink())
+                .thirdOpenChatLink(dto.thirdOpenChatLink())
+                .fourthOpenChatLink(dto.fourthOpenChatLink())
+                .firstDocumentLink(dto.firstDocumentLink())
+                .secondDocumentLink(dto.secondDocumentLink())
+                .thridDocumentLink(dto.thridDocumentLink())
+                .fourthDocumentLink(dto.fourthDocumentLink())
+                .build();
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/entity/InterviewPlace.java
@@ -35,16 +35,16 @@ public class InterviewPlace extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     public String fourthOpenChatLink;
 
-    @Column(columnDefinition = "TEXTX")
+    @Column(columnDefinition = "TEXT")
     public String firstDocumentLink;
 
-    @Column(columnDefinition = "TEXTX")
+    @Column(columnDefinition = "TEXT")
     public String secondDocumentLink;
 
-    @Column(columnDefinition = "TEXTX")
+    @Column(columnDefinition = "TEXT")
     public String thridDocumentLink;
 
-    @Column(columnDefinition = "TEXTX")
+    @Column(columnDefinition = "TEXT")
     public String fourthDocumentLink;
 
     public static InterviewPlace of(InterviewPlaceSaveDto dto) {

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/exception/ErrorMessage.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.interviewplace.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    NOT_FOUNT_INTERVIEW_PLACE(400,"아직 등록된 면접 장소 정보가 없습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/exception/NotFoundInterviewPlaceException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/exception/NotFoundInterviewPlaceException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.interviewplace.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.interviewplace.exception.ErrorMessage.NOT_FOUNT_INTERVIEW_PLACE;
+
+public class NotFoundInterviewPlaceException extends BaseErrorException {
+    public NotFoundInterviewPlaceException() {
+        super(NOT_FOUNT_INTERVIEW_PLACE.getCode(), NOT_FOUNT_INTERVIEW_PLACE.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/repository/InterviewPlaceRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/repository/InterviewPlaceRepository.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.interviewplace.repository;
+
+import com.tave.tavewebsite.domain.interviewplace.entity.InterviewPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface InterviewPlaceRepository extends JpaRepository<InterviewPlace, Integer> {
+
+    // FIXME 아직 조회 기준을 몰라서 일단 createdAt으로 조회함.
+    Optional<InterviewPlace> findFirstByOrderByCreatedAtDesc();
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.interviewplace.service;
 import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSaveDto;
 import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceResponse;
 import com.tave.tavewebsite.domain.interviewplace.entity.InterviewPlace;
+import com.tave.tavewebsite.domain.interviewplace.exception.NotFoundInterviewPlaceException;
 import com.tave.tavewebsite.domain.interviewplace.repository.InterviewPlaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,13 @@ public class InterviewPlaceService {
         InterviewPlace interviewPlace = InterviewPlace.of(dto);
 
         return InterviewPlaceResponse.of(interviewPlaceRepository.save(interviewPlace));
+    }
+
+    public InterviewPlaceResponse getInterviewPlace() {
+        InterviewPlace findEntity = interviewPlaceRepository.findFirstByOrderByCreatedAtDesc()
+                .orElseThrow(NotFoundInterviewPlaceException::new);
+
+        return InterviewPlaceResponse.of(findEntity);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.domain.interviewplace.service;
+
+import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSaveDto;
+import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceResponse;
+import com.tave.tavewebsite.domain.interviewplace.entity.InterviewPlace;
+import com.tave.tavewebsite.domain.interviewplace.repository.InterviewPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewPlaceService {
+
+    private final InterviewPlaceRepository interviewPlaceRepository;
+
+    public InterviewPlaceResponse saveInterviewPlace(InterviewPlaceSaveDto dto) {
+
+        InterviewPlace interviewPlace = InterviewPlace.of(dto);
+
+        return InterviewPlaceResponse.of(interviewPlaceRepository.save(interviewPlace));
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #130 
> Close #130

## 📑 작업 내용
> - 면접 설정 API를 구현했습니다.

면접 설정 페이지를 위한 API 구현

![image](https://github.com/user-attachments/assets/d6ba1556-2f1e-4972-bb2e-d68033c57d5b)

- 위 페이지 구현을 위해 시군구를 나타내는 generalAddress와 상세 주소를 나타내는 detailAddress필드로 주소 필드를 나눴습니다.
- Link 필드는 TEXT로 설정했습니다.

- 일단 면접이 나흘 동안 이루어지는 것을 구현하기 위해 first ~ fourth로 필드에 하드코딩 해두었습니다.
훗날 변경 가능성이 있습니다.
- 면접 정보 수정과 삭제는 보이지 않아 구현하지 않았습니다.
- 면접 정보 조회 시 조건이 명확하지 않아 가장 최근 생성된 면접 정보를 반환하도록 했습니다.




## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
