### PR TITLE
fix: 전체 개인정보 조회, memberId로 개인정보 수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -34,14 +34,22 @@ public class PersonalInfoController {
         return new SuccessResponse<>(response, PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
     }
 
-    // 개인정보 조회
-    @GetMapping("/{resumeId}")
-    public SuccessResponse<PersonalInfoResponseDto> getPersonalInfo(@PathVariable("resumeId") Long resumeId) {
-        return new SuccessResponse<>(personalInfoService.getPersonalInfo(resumeId),
-                READ_SUCCESS.getMessage());
+    // 전체 개인정보 조회
+    @GetMapping("/{memberId}")
+    public SuccessResponse<PersonalInfoResponseDto> getAllPersonalInfo(@PathVariable("memberId") Long memberId) {
+        PersonalInfoResponseDto response = personalInfoService.getAllPersonalInfo(memberId);
+        return new SuccessResponse<>(response, READ_SUCCESS.getMessage());
     }
 
-    // 개인정보 수정
+    // 이력서 정보 수정 (memberId)
+    @PatchMapping("/update/{memberId}")
+    public SuccessResponse updatePersonalResumeInfo(@PathVariable("memberId") Long memberId,
+                                                    @RequestBody @Valid PersonalInfoRequestDto requestDto) {
+        personalInfoService.updatePersonalInfoByMemberId(memberId, requestDto);
+        return SuccessResponse.ok(UPDATE_SUCCESS.getMessage());
+    }
+
+    // 개인정보 수정 (resumeId)
     @PatchMapping("/{resumeId}")
     public SuccessResponse updatePersonalInfo(@PathVariable("resumeId") Long resumeId,
                                               @RequestBody @Valid PersonalInfoRequestDto requestDto) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/PersonalInfoResponseDto.java
@@ -1,13 +1,25 @@
 package com.tave.tavewebsite.domain.resume.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PersonalInfoResponseDto {
-    private final String school;
-    private final String major;
-    private final String minor;
-    private final String field;
+    // 회원 정보
+    private String username;
+    private String sex;
+    private String birthday;
+    private String phoneNumber;
+    private String email;
+
+    // 이력서 정보
+    private String school;
+    private String major;
+    private String minor;
+    private String field;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -138,11 +138,13 @@ public class PersonalInfoService {
 
     @Transactional
     public void updatePersonalInfoByMemberId(Long memberId, PersonalInfoRequestDto requestDto) {
-        Resume resume = resumeRepository.findByMemberId(memberId)
-                .orElseThrow(ResumeNotFoundException::new);
-
         FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
-        resume.updatePersonalInfo(requestDto, fieldType);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        resumeRepository.findByMemberId(memberId)
+                .ifPresent(resume -> resume.updatePersonalInfo(requestDto, fieldType));
     }
 
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -86,13 +86,6 @@ public class PersonalInfoService {
         }
     }
 
-    public PersonalInfoResponseDto getPersonalInfo(Long resumeId) {
-        Resume resume = resumeRepository.findById(resumeId)
-                .orElseThrow(ResumeNotFoundException::new);
-
-        return ResumeMapper.toPersonalInfoResponseDto(resume);
-    }
-
     @Transactional
     public void updatePersonalInfo(Long resumeId, PersonalInfoRequestDto requestDto) {
         Resume resume = resumeRepository.findById(resumeId)
@@ -122,5 +115,35 @@ public class PersonalInfoService {
         return resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
     }
+
+    public PersonalInfoResponseDto getAllPersonalInfo(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Resume resume = resumeRepository.findByMemberId(memberId)
+                .orElse(null); // 없을 수도 있음
+
+        return PersonalInfoResponseDto.builder()
+                .username(member.getUsername())
+                .sex(member.getSex().name())
+                .birthday(member.getBirthday().toString())
+                .phoneNumber(member.getPhoneNumber())
+                .email(member.getEmail())
+                .school(resume != null ? resume.getSchool() : null)
+                .major(resume != null ? resume.getMajor() : null)
+                .minor(resume != null ? resume.getMinor() : null)
+                .field(resume != null ? resume.getField().name() : null)
+                .build();
+    }
+
+    @Transactional
+    public void updatePersonalInfoByMemberId(Long memberId, PersonalInfoRequestDto requestDto) {
+        Resume resume = resumeRepository.findByMemberId(memberId)
+                .orElseThrow(ResumeNotFoundException::new);
+
+        FieldType fieldType = validateAndConvertFieldType(requestDto.getField());
+        resume.updatePersonalInfo(requestDto, fieldType);
+    }
+
 
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #132
> Close #132

## 📑 작업 내용
> - 개인정보 조회 시 전체 정보 조회 (기존엔 새로 입력받은 내용만 조회했음)
> - 개인정보 수정 시 memberId로 수정하는 api 추가 (임시저장 전 수정할 경우 위해)

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
