### PR TITLE
fix: 지원서 수정

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/question/dto/request/QuestionSaveRequest.java
+++ b/src/main/java/com/tave/tavewebsite/domain/question/dto/request/QuestionSaveRequest.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.question.dto.request;
 
+import com.tave.tavewebsite.domain.resume.entity.AnswerType;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -10,6 +11,7 @@ public record QuestionSaveRequest(
         @NotBlank(message = "질문 내용을 입력해주세요.") String content,
         @NotNull FieldType fieldType,
         @NotNull Integer ordered,
-        @NotNull Integer textLength
-) {
+        @NotNull Integer textLength,
+        @NotNull AnswerType answerType
+        ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/question/dto/request/QuestionUpdateRequest.java
+++ b/src/main/java/com/tave/tavewebsite/domain/question/dto/request/QuestionUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.question.dto.request;
 
+import com.tave.tavewebsite.domain.resume.entity.AnswerType;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -9,6 +10,7 @@ public record QuestionUpdateRequest(
         @NotBlank(message = "질문 수정 내용을 입력해주세요.") String content,
         @NotNull(message = "질문 분야를 입력해주세요") FieldType fieldType,
         @NotNull(message = "질문 우선순위를 입력해주세요.") Integer ordered,
-        @NotNull(message = "제한 글자수를 입력해주세요") Integer textLength
+        @NotNull(message = "제한 글자수를 입력해주세요") Integer textLength,
+        @NotNull(message = "답변 타입을 입력해주세요") AnswerType answerType
 ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/question/dto/response/QuestionDetailsResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/question/dto/response/QuestionDetailsResponse.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.question.dto.response;
 
 import com.tave.tavewebsite.domain.question.entity.Question;
+import com.tave.tavewebsite.domain.resume.entity.AnswerType;
 import com.tave.tavewebsite.global.common.FieldType;
 import lombok.Builder;
 
@@ -10,7 +11,8 @@ public record QuestionDetailsResponse(
         String content,
         FieldType fieldType,
         Integer ordered,
-        Integer textLength
+        Integer textLength,
+        AnswerType answerType
 ) {
     public static QuestionDetailsResponse of(Question question) {
         return QuestionDetailsResponse.builder()
@@ -19,6 +21,7 @@ public record QuestionDetailsResponse(
                 .fieldType(question.getFieldType())
                 .ordered(question.getOrdered())
                 .textLength(question.getTextLength())
+                .answerType(question.getAnswerType())
                 .build();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/question/entity/Question.java
+++ b/src/main/java/com/tave/tavewebsite/domain/question/entity/Question.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.question.entity;
 
 import com.tave.tavewebsite.domain.question.dto.request.QuestionSaveRequest;
 import com.tave.tavewebsite.domain.question.dto.request.QuestionUpdateRequest;
+import com.tave.tavewebsite.domain.resume.entity.AnswerType;
 import com.tave.tavewebsite.global.common.BaseEntity;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.persistence.*;
@@ -36,6 +37,12 @@ public class Question extends BaseEntity {
     @Column(nullable = false)
     private Integer ordered;
 
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AnswerType answerType;
+
+
     private Integer textLength;
 
     public static Question from(QuestionSaveRequest dto) {
@@ -44,6 +51,7 @@ public class Question extends BaseEntity {
                 .fieldType(dto.fieldType())
                 .ordered(dto.ordered())
                 .textLength(dto.textLength())
+                .answerType(dto.answerType())
                 .build();
     }
 
@@ -52,5 +60,6 @@ public class Question extends BaseEntity {
         this.fieldType = dto.fieldType();
         this.ordered = dto.ordered();
         this.textLength = dto.textLength();
+        this.answerType = dto.answerType();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -5,6 +5,7 @@ import com.tave.tavewebsite.domain.resume.dto.request.TempPersonalInfoDto;
 import com.tave.tavewebsite.domain.resume.dto.response.CreatePersonalInfoResponse;
 import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeQuestionResponse;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
@@ -26,10 +27,14 @@ public class PersonalInfoController {
     @PostMapping("/{memberId}")
     public SuccessResponse<CreatePersonalInfoResponse> createPersonalInfoWithQuestions(@PathVariable("memberId") Long memberId,
                                                                                        @RequestBody @Valid PersonalInfoRequestDto requestDto) {
-        ResumeQuestionResponse questions = personalInfoService.createPersonalInfo(memberId, requestDto);
+        Resume resume = personalInfoService.createPersonalInfo(memberId, requestDto);
+        ResumeQuestionResponse questions = personalInfoService.createResumeQuestions(resume);
 
         CreatePersonalInfoResponse response = CreatePersonalInfoResponse.of(
-                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(), questions);
+                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(),
+                questions,
+                resume.getId()
+        );
 
         return new SuccessResponse<>(response, PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -84,4 +84,11 @@ public class PersonalInfoController {
         return new SuccessResponse<>(response, TEMP_LOAD_SUCCESS.getMessage());
     }
 
+    // 지원서 최종 제출
+    @PostMapping("/{resumeId}/submit")
+    public SuccessResponse<String> submitResume(@PathVariable("resumeId") Long resumeId) {
+        personalInfoService.submitResume(resumeId);
+        return SuccessResponse.ok(SUBMIT_SUCCESS.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoSuccessMessage.java
@@ -1,7 +1,9 @@
 package com.tave.tavewebsite.domain.resume.controller;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor
 public enum PersonalInfoSuccessMessage {
     CREATE_SUCCESS("개인정보 작성에 성공했습니다."),
@@ -10,11 +12,9 @@ public enum PersonalInfoSuccessMessage {
     DELETE_SUCCESS("개인정보 삭제에 성공했습니다."),
     QUESTION_READ_SUCCESS("질문과 답변 조회에 성공했습니다."),
     TEMP_SAVE_SUCCESS("임시 저장에 성공했습니다."),
-    TEMP_LOAD_SUCCESS("임시 저장 조회에 성공했습니다.");
+    TEMP_LOAD_SUCCESS("임시 저장 조회에 성공했습니다."),
+    SUBMIT_SUCCESS("지원서가 최종 제출되었습니다.");
 
     private final String message;
 
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CreatePersonalInfoResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CreatePersonalInfoResponse.java
@@ -8,8 +8,9 @@ import lombok.Getter;
 public class CreatePersonalInfoResponse {
     private String message;
     private ResumeQuestionResponse resumeQuestions;
+    private Long resumeId;
 
-    public static CreatePersonalInfoResponse of(String message, ResumeQuestionResponse resumeQuestions) {
-        return new CreatePersonalInfoResponse(message, resumeQuestions);
+    public static CreatePersonalInfoResponse of(String message, ResumeQuestionResponse resumeQuestions, Long resumeId) {
+        return new CreatePersonalInfoResponse(message, resumeQuestions, resumeId);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/DetailResumeQuestionResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/DetailResumeQuestionResponse.java
@@ -1,17 +1,18 @@
 package com.tave.tavewebsite.domain.resume.dto.response;
 
+import com.tave.tavewebsite.domain.resume.entity.AnswerType;
 import com.tave.tavewebsite.domain.resume.entity.ResumeQuestion;
 import com.tave.tavewebsite.global.common.FieldType;
 import lombok.Builder;
 
 @Builder
 public record DetailResumeQuestionResponse(
-
         Long id,
         String question,
         String answer,
         FieldType fieldType,
-        Integer ordered
+        Integer ordered,
+        AnswerType answerType
 
 ) {
     public static DetailResumeQuestionResponse from(ResumeQuestion resumeQuestion) {
@@ -21,6 +22,7 @@ public record DetailResumeQuestionResponse(
                 .answer(resumeQuestion.getAnswer())
                 .fieldType(resumeQuestion.getFieldType())
                 .ordered(resumeQuestion.getOrdered())
+                .answerType(resumeQuestion.getAnswerType())
                 .build();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/AnswerType.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/AnswerType.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+public enum AnswerType {
+    TEXTAREA,
+    PROGRAMMING,
+    URL,
+    TIME
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/AnswerType.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/AnswerType.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.resume.entity;
 public enum AnswerType {
     TEXTAREA,
     PROGRAMMING,
+    INPUT,
     URL,
-    TIME
+    TIME,
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
+import com.tave.tavewebsite.domain.resume.exception.AlreadySubmittedResumeException;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -62,9 +63,9 @@ public class Resume {
     @Column(length = 50)
     private String portfolioUrl;
 
-    @Size(min = 1, max = 10)
     @Column(length = 10)
-    private String state;
+    @Enumerated(EnumType.STRING)
+    private ResumeState state = ResumeState.TEMPORARY;
 
     @ManyToOne
     @JoinColumn(name = "memberId", nullable = false)
@@ -81,7 +82,7 @@ public class Resume {
 
     @Builder
     public Resume(String school, String major, String minor, Integer resumeGeneration, String blogUrl, String githubUrl,
-                  String portfolioUrl, String state, FieldType field, Member member) {
+                  String portfolioUrl, ResumeState state, FieldType field, Member member) {
         this.school = school;
         this.major = major;
         this.minor = minor;
@@ -119,4 +120,12 @@ public class Resume {
     public void updatePortfolio(String portfolioUrl) {
         this.portfolioUrl = portfolioUrl;
     }
+
+    public void submit() {
+        if (this.state == ResumeState.SUBMITTED) {
+            throw new AlreadySubmittedResumeException();
+        }
+        this.state = ResumeState.SUBMITTED;
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeQuestion.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeQuestion.java
@@ -56,6 +56,7 @@ public class ResumeQuestion extends BaseEntity {
                 .question(question.getContent())
                 .fieldType(question.getFieldType())
                 .ordered(question.getOrdered()) // todo Question 순서 사용 or 자체 ResumeQuestion 순서 생성? 의논
+                .answerType(question.getAnswerType())
                 .build();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeQuestion.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeQuestion.java
@@ -45,6 +45,10 @@ public class ResumeQuestion extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private FieldType fieldType;
 
+    @Enumerated(EnumType.STRING)
+    private AnswerType answerType;
+
+
     public static ResumeQuestion of(Resume resume, Question question) {
 
         return ResumeQuestion.builder()

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeState.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeState.java
@@ -1,0 +1,6 @@
+package com.tave.tavewebsite.domain.resume.entity;
+
+public enum ResumeState {
+    TEMPORARY, // 임시저장
+    SUBMITTED, // 제출완료
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/AlreadySubmittedResumeException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/AlreadySubmittedResumeException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.ALREADY_SUBMITTED;
+
+public class AlreadySubmittedResumeException extends BaseErrorException {
+    public AlreadySubmittedResumeException() {
+        super(ALREADY_SUBMITTED.getCode(), ALREADY_SUBMITTED.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -20,6 +20,7 @@ public enum ErrorMessage {
     FIELD_TYPE_INVALID(400, "유효하지 않은 필드 타입입니다."),
 
     INVALID_PAGE_NUMBER(400, "유효하지 않은 페이지 번호입니다."),
+    ALREADY_SUBMITTED(400, "이미 제출된 이력서입니다."),
 
     // Redis 임시 저장
     TEMP_NOT_FOUND(404, "임시 저장된 정보가 없습니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -152,5 +152,10 @@ public class PersonalInfoService {
                 .ifPresent(resume -> resume.updatePersonalInfo(requestDto, fieldType));
     }
 
+    public void submitResume(Long resumeId) {
+        Resume resume = getResumeEntityById(resumeId);
+        resume.submit();
+        resumeRepository.save(resume);
+    }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -38,7 +38,7 @@ public class PersonalInfoService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public ResumeQuestionResponse createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
+    public Resume createPersonalInfo(Long memberId, PersonalInfoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
@@ -49,8 +49,13 @@ public class PersonalInfoService {
         List<LanguageLevel> languageLevels = LanguageLevelMapper.toLanguageLevel(byField, savedResume);
         languageLevelRepository.saveAll(languageLevels);
 
-        return resumeQuestionService.createResumeQuestion(savedResume, fieldType);
+        return savedResume;
     }
+
+    public ResumeQuestionResponse createResumeQuestions(Resume resume) {
+        return resumeQuestionService.createResumeQuestion(resume, resume.getField());
+    }
+
 
     // 임시 저장 기능 (현재까지 입력한 정보 저장)
     @Transactional


### PR DESCRIPTION
## ➕ 연관된 이슈
> #134 
> Close #134 

## 📑 작업 내용
- 지원서 최종 제출 api 추가
> 지원서 최종 제출 시 상태 변경 후, 수정 불가하도록 설정
> 최종 제출 전까진 redis에 임시저장, 최종 제출 후 DB에 저장되도록 최종 제출 로직 추후 수정할 예정
- 지원서 생성 시 resumeId 응답 바디에 추가
- 질문 답변 타입 필드 추가 `answerType`

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
