### PR TITLE
Feat 최종 면접 시간표 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 //    implementation "com.sksamuel.scrimage:scrimage-core:4.3.0"
     implementation "com.sksamuel.scrimage:scrimage-webp:4.3.0"
 
+    // POI for Excel
+    implementation("org.apache.poi:poi:5.4.0")
+    implementation("org.apache.poi:poi-ooxml:5.4.0")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -1,0 +1,46 @@
+package com.tave.tavewebsite.domain.interviewfinal.controller;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFormInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.usecase.InterviewFinalUseCase;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_FINAL_CREATED;
+
+@RestController
+@RequiredArgsConstructor
+public class InterviewFinalController {
+
+    private final InterviewFinalUseCase interviewFinalUseCase;
+
+    @GetMapping("/v1/manager/interview-final/form")
+    public ResponseEntity<InputStreamResource> interviewFinalForm() throws IOException {
+
+        InterviewFormInputStreamDto dto = interviewFinalUseCase.downloadInterviewFinal();
+
+        return ResponseEntity.ok()
+                .headers(dto.headers())
+                .contentLength(dto.contentLength())
+                .body(dto.inputStreamResource());
+    }
+
+    @PostMapping("/v1/manager/interview-final")
+    public SuccessResponse interviewFinal(
+            @RequestPart(name="file")MultipartFile file
+    )
+    {
+        interviewFinalUseCase.insertInterviewEntityFromExcel(file);
+
+        return SuccessResponse.ok(INTERVIEW_FINAL_CREATED.getMessage());
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -1,20 +1,20 @@
 package com.tave.tavewebsite.domain.interviewfinal.controller;
 
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFormInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalDetailDto;
 import com.tave.tavewebsite.domain.interviewfinal.usecase.InterviewFinalUseCase;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_FINAL_CREATED;
+import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_FINAL_LIST_GET;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,6 +41,16 @@ public class InterviewFinalController {
         interviewFinalUseCase.insertInterviewEntityFromExcel(file);
 
         return SuccessResponse.ok(INTERVIEW_FINAL_CREATED.getMessage());
+    }
+
+    @GetMapping("/v1/manager/interview-final")
+    public SuccessResponse interviewFinalPageNation(
+        @RequestParam int pageNum,
+        @RequestParam int pageSize
+    ) {
+        List<InterviewFinalDetailDto> response = interviewFinalUseCase.getInterviewFinalList(pageNum, pageSize);
+
+        return new SuccessResponse(response, INTERVIEW_FINAL_LIST_GET.getMessage());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -33,14 +33,4 @@ public class InterviewFinalController {
                 .body(dto.inputStreamResource());
     }
 
-    @PostMapping("/v1/manager/interview-final")
-    public SuccessResponse interviewFinal(
-            @RequestPart(name="file")MultipartFile file
-    )
-    {
-        interviewFinalUseCase.insertInterviewEntityFromExcel(file);
-
-        return SuccessResponse.ok(INTERVIEW_FINAL_CREATED.getMessage());
-    }
-
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -33,4 +33,14 @@ public class InterviewFinalController {
                 .body(dto.inputStreamResource());
     }
 
+    @PostMapping("/v1/manager/interview-final")
+    public SuccessResponse interviewFinal(
+            @RequestPart(name="file")MultipartFile file
+    )
+    {
+        interviewFinalUseCase.insertInterviewEntityFromExcel(file);
+
+        return SuccessResponse.ok(INTERVIEW_FINAL_CREATED.getMessage());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -7,9 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    INTERVIEW_PLACE_GET("면접 장소 정보를 조회합니다"),
-    INTERVIEW_PLACE_CREATED("면접 장소 정보를 성공적으로 생성했습니다.");
+    INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다.");
 
-
+    private final int code;
     private final String message;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다.");
+    INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다."),
+    INTERVIEW_FINAL_LIST_GET(200, "최종 면접 페이지네이션 데이터를 반환합니다");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFinalConvertDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFinalConvertDto.java
@@ -1,0 +1,33 @@
+package com.tave.tavewebsite.domain.interviewfinal.dto;
+
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.Builder;
+
+
+@Builder
+public record InterviewFinalConvertDto(
+        String username,
+        String email,
+        Integer generation,
+        Sex sex,
+        FieldType fieldType,
+        String university,
+        String interviewDay,
+        String interviewTime
+) {
+
+    public static InterviewFinalConvertDto from(String username, String email, Integer generation, Sex sex, FieldType fieldType, String university, String interviewDay, String interviewTime) {
+        return InterviewFinalConvertDto.builder()
+                .username(username)
+                .email(email)
+                .generation(generation)
+                .sex(sex)
+                .fieldType(fieldType)
+                .university(university)
+                .interviewDay(interviewDay)
+                .interviewTime(interviewTime)
+                .build();
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFinalSaveDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFinalSaveDto.java
@@ -1,0 +1,64 @@
+package com.tave.tavewebsite.domain.interviewfinal.dto;
+
+import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.Builder;
+
+@Builder
+public record InterviewFinalSaveDto(
+        String username,
+        String email,
+        Integer generation,
+        Sex sex,
+        FieldType fieldType,
+        String university,
+        String interviewDay,
+        String interviewTime,
+        Long memberId,
+        Long resumeId
+) {
+    public static InterviewFinalSaveDto analysisSucceeded(InterviewFinalConvertDto interviewDto, MemberResumeDto memberResumeDto) {
+        return InterviewFinalSaveDto.builder()
+                .username(interviewDto.username())
+                .email(interviewDto.email())
+                .generation(interviewDto.generation())
+                .sex(interviewDto.sex())
+                .fieldType(interviewDto.fieldType())
+                .university(interviewDto.university())
+                .interviewDay(interviewDto.interviewDay())
+                .interviewTime(interviewDto.interviewTime())
+                .memberId(memberResumeDto.memberId())
+                .resumeId(memberResumeDto.resumeId())
+                .build();
+    }
+
+    public static InterviewFinalSaveDto analysisFailed(InterviewFinalConvertDto dto) {
+        /*
+        * Q email 조회 실패 시 interviewDay와 interviewTime도 "분석 실패"로 저장할 지..?
+        * 현재는 2안
+        *
+        * ex. email: 잘못된 이메일, interviewDay: 10월 10일, interviewTime: 13:00
+        * 위와 같은 경우
+        * 1안 - DB에 email: "분석 실패", interviewDay: "분석 실패" , interviewTime: "분석 실패"
+        * or
+        * 2안 - DB에 email: "분석 실패", interviewDay: "10월 10일" , interviewTime: "13:00"
+        * */
+        return InterviewFinalSaveDto.builder()
+                .username(dto.username())
+                .email(dto.email())
+                .generation(dto.generation())
+                .sex(dto.sex())
+                .fieldType(dto.fieldType())
+                .university(dto.university())
+                .interviewDay(dto.interviewDay())
+                .interviewTime(dto.interviewTime())
+                .memberId(null)
+                .resumeId(null)
+                .build();
+    }
+
+
+
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFormInputStreamDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/InterviewFormInputStreamDto.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.domain.interviewfinal.dto;
+
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import lombok.Builder;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
+
+import java.io.IOException;
+
+@Builder
+public record InterviewFormInputStreamDto(
+        InputStreamResource inputStreamResource,
+        HttpHeaders headers,
+        long contentLength
+) {
+    public static InterviewFormInputStreamDto from(S3ObjectInputStream s3ObjectInputStream, HttpHeaders headers, long contentLength) throws IOException {
+        return InterviewFormInputStreamDto.builder()
+                .inputStreamResource(new InputStreamResource(s3ObjectInputStream))
+                .headers(headers)
+                .contentLength(contentLength)
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/response/InterviewFinalDetailDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/response/InterviewFinalDetailDto.java
@@ -1,0 +1,33 @@
+package com.tave.tavewebsite.domain.interviewfinal.dto.response;
+
+import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
+import lombok.Builder;
+
+
+@Builder
+public record InterviewFinalDetailDto(
+        Long id,
+        String field,
+        String username,
+        String sex,
+        String university,
+        String interviewDate,
+        Long memberId,
+        Long resumeId
+) {
+    public static InterviewFinalDetailDto from(InterviewFinal interviewFinal) {
+
+        String interviewDate = interviewFinal.getInterviewDay() + " " + interviewFinal.getInterviewTime();
+
+        return InterviewFinalDetailDto.builder()
+                .id(interviewFinal.getId())
+                .field(interviewFinal.getFieldType().getDisplayName())
+                .username(interviewFinal.getUsername())
+                .sex(interviewFinal.getSex().getDisplayName())
+                .university(interviewFinal.getUniversity())
+                .interviewDate(interviewDate)
+                .memberId(interviewFinal.getMemberId())
+                .resumeId(interviewFinal.getResumeId())
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/entity/InterviewFinal.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/entity/InterviewFinal.java
@@ -1,0 +1,46 @@
+package com.tave.tavewebsite.domain.interviewfinal.entity;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.BaseEntity;
+import com.tave.tavewebsite.global.common.FieldType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewFinal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    private String email;
+
+    private Integer generation;
+
+    @Enumerated(EnumType.STRING)
+    private Sex sex;
+
+    @Enumerated(EnumType.STRING)
+    private FieldType fieldType;
+
+    private String university;
+
+    private String interviewDay;
+
+    private String interviewTime;
+
+    private Long memberId;
+
+    private Long resumeId;
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.interviewfinal.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    EXCEL_BAD_REQUEST_EXCEPTION(400, "엑셀 오류"),
+    EXCEL_NULL_EXCEPTION(400,"현재 서버에서는 엑셀로부터 Null 값을 인식하고 있습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ExcelBadRequestException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ExcelBadRequestException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.interviewfinal.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.exception.ErrorMessage.EXCEL_BAD_REQUEST_EXCEPTION;
+
+public class ExcelBadRequestException extends BaseErrorException {
+    public ExcelBadRequestException() {
+        super(EXCEL_BAD_REQUEST_EXCEPTION.getCode(), EXCEL_BAD_REQUEST_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ExcelNullPointException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ExcelNullPointException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.interviewfinal.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.exception.ErrorMessage.EXCEL_NULL_EXCEPTION;
+
+public class ExcelNullPointException extends BaseErrorException {
+    public ExcelNullPointException() {
+        super(EXCEL_NULL_EXCEPTION.getCode(), EXCEL_NULL_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalJdbcRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalJdbcRepository.java
@@ -1,0 +1,51 @@
+package com.tave.tavewebsite.domain.interviewfinal.repository;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class InterviewFinalJdbcRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public int[] bulkInsert(List<InterviewFinalSaveDto> dtoList) {
+
+        // INSERT 쿼리
+        String sql = """
+            INSERT INTO interview_final (username, last_tel, generation, sex, university, field_type, member_id, resume_id, interview_day, interview_time , created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+        """;
+
+        return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                InterviewFinalSaveDto dto = dtoList.get(i);
+                ps.setString(1, dto.username());
+                ps.setString(2, dto.email());
+                ps.setInt(3, dto.generation());
+                ps.setString(4, dto.sex().name());
+                ps.setString(5, dto.university());
+                ps.setString(6, dto.fieldType().name());
+                ps.setInt(7, dto.memberId().intValue());
+                ps.setInt(8, dto.resumeId().intValue());
+                ps.setString(9, dto.interviewDay());
+                ps.setString(10, dto.interviewTime());
+            }
+
+            @Override
+            public int getBatchSize() {
+                return dtoList.size();
+            }
+        });
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalJdbcRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalJdbcRepository.java
@@ -21,7 +21,7 @@ public class InterviewFinalJdbcRepository {
 
         // INSERT 쿼리
         String sql = """
-            INSERT INTO interview_final (username, last_tel, generation, sex, university, field_type, member_id, resume_id, interview_day, interview_time , created_at, updated_at)
+            INSERT INTO interview_final (username, email, generation, sex, university, field_type, member_id, resume_id, interview_day, interview_time , created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         """;
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
@@ -11,4 +11,6 @@ public interface InterviewFinalRepository extends JpaRepository<InterviewFinal, 
 
     Page<InterviewFinal> findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc(Pageable pageable);
 
+    List<InterviewFinal> findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc();
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
@@ -1,7 +1,13 @@
 package com.tave.tavewebsite.domain.interviewfinal.repository;
 
 import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InterviewFinalRepository extends JpaRepository<InterviewFinal, Integer> {
+
+    Page<InterviewFinal> findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc(Pageable pageable);
+
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.interviewfinal.repository;
+
+import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterviewFinalRepository extends JpaRepository<InterviewFinal, Integer> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/repository/InterviewFinalRepository.java
@@ -5,9 +5,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InterviewFinalRepository extends JpaRepository<InterviewFinal, Integer> {
 
     Page<InterviewFinal> findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc(Pageable pageable);
-
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewExcelService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewExcelService.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.interviewfinal.service;
 
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
 import com.tave.tavewebsite.domain.interviewfinal.exception.ExcelBadRequestException;
+import com.tave.tavewebsite.domain.interviewfinal.exception.ExcelNullPointException;
 import com.tave.tavewebsite.domain.interviewfinal.utils.ExcelUtils;
 import com.tave.tavewebsite.domain.member.entity.Sex;
 import com.tave.tavewebsite.global.common.FieldType;
@@ -45,6 +46,8 @@ public class InterviewExcelService {
                 dtoList.add(dto);
             }
 
+        }catch (NullPointerException e) {
+            throw new ExcelNullPointException();
         }catch (IOException e) {
             throw new ExcelBadRequestException();
         }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewExcelService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewExcelService.java
@@ -1,0 +1,75 @@
+package com.tave.tavewebsite.domain.interviewfinal.service;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
+import com.tave.tavewebsite.domain.interviewfinal.exception.ExcelBadRequestException;
+import com.tave.tavewebsite.domain.interviewfinal.utils.ExcelUtils;
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InterviewExcelService {
+
+    private final ExcelUtils excelUtils;
+
+    public List<InterviewFinalConvertDto> exportInterviewFinalFromExcel(MultipartFile file) {
+        List<InterviewFinalConvertDto> dtoList = new ArrayList<>();
+        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
+            Sheet sheet = workbook.getSheetAt(0);
+            logExcelLastRowNum(sheet);
+            boolean isFirstRow = true;
+
+            for (Row row : sheet) {
+                // 0행 스킵
+                if (isFirstRow) {
+                    isFirstRow = false;
+                    continue;
+                }
+                // 빈 행 스킵
+                if (row == null || row.getCell(0) == null) continue;
+
+                InterviewFinalConvertDto dto = convertRowToInterviewFinal(row);
+                dtoList.add(dto);
+            }
+
+        }catch (IOException e) {
+            throw new ExcelBadRequestException();
+        }
+
+        return dtoList;
+    }
+
+    private InterviewFinalConvertDto convertRowToInterviewFinal(Row row) {
+        String username = excelUtils.getStringToCell(row.getCell(0));
+        Sex sex = excelUtils.StringConvertToSex(excelUtils.getStringToCell(row.getCell(1)));
+        String email = excelUtils.getStringToCell(row.getCell(2));
+        FieldType field = excelUtils.StringConvertToField(excelUtils.getStringToCell(row.getCell(3)));
+        String university = excelUtils.getStringToCell(row.getCell(4));
+        String interviewDay = excelUtils.getDayToCell(row.getCell(5));
+        String interviewTime = excelUtils.getTimeToCell(row.getCell(6));
+        Integer generation = excelUtils.getIntegerToCell(row.getCell(7));
+
+        return InterviewFinalConvertDto
+                .from(username, email, generation, sex, field, university, interviewDay, interviewTime);
+    }
+
+    private void logExcelLastRowNum(Sheet sheet) {
+        log.info("=============================");
+        log.info("서버에서 인식하는 Excel 마지막 행 번호: {}", sheet.getLastRowNum());
+        log.info("=============================");
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewGetService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewGetService.java
@@ -7,14 +7,20 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class InterviewGetService {
 
     private final InterviewFinalRepository interviewFinalRepository;
 
-    public Page<InterviewFinal> getInterviewFinalList(Pageable pageable) {
+    public Page<InterviewFinal> getInterviewFinalPageableList(Pageable pageable) {
         return interviewFinalRepository.findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc(pageable);
+    }
+
+    public List<InterviewFinal> getInterviewFinalList() {
+        return interviewFinalRepository.findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc();
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewGetService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewGetService.java
@@ -1,0 +1,20 @@
+package com.tave.tavewebsite.domain.interviewfinal.service;
+
+import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
+import com.tave.tavewebsite.domain.interviewfinal.repository.InterviewFinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewGetService {
+
+    private final InterviewFinalRepository interviewFinalRepository;
+
+    public Page<InterviewFinal> getInterviewFinalList(Pageable pageable) {
+        return interviewFinalRepository.findAllByOrderByInterviewDayAscInterviewTimeAscUsernameAsc(pageable);
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewSaveService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewSaveService.java
@@ -1,0 +1,23 @@
+package com.tave.tavewebsite.domain.interviewfinal.service;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
+import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
+import com.tave.tavewebsite.domain.interviewfinal.repository.InterviewFinalJdbcRepository;
+import com.tave.tavewebsite.domain.interviewfinal.repository.InterviewFinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewSaveService {
+
+    private final InterviewFinalJdbcRepository interviewFinalJdbcRepository;
+
+    public void saveInterviewFinalList(List<InterviewFinalSaveDto> dto) {
+        interviewFinalJdbcRepository.bulkInsert(dto);
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -3,13 +3,17 @@ package com.tave.tavewebsite.domain.interviewfinal.usecase;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFormInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalDetailDto;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
+import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewSaveService;
 import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
 import com.tave.tavewebsite.domain.member.service.AdminService;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.s3.service.S3DownloadSerivce;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +30,7 @@ public class InterviewFinalUseCase {
 
     private final InterviewExcelService interviewExcelService;
     private final InterviewSaveService interviewSaveService;
+    private final InterviewGetService interviewGetService;
     private final S3DownloadSerivce s3DownloadSerivce;
     private final MemberService memberService;
 
@@ -53,6 +58,16 @@ public class InterviewFinalUseCase {
         // BulkInsert
         interviewSaveService.saveInterviewFinalList(pairedList);
 
+    }
+
+    public List<InterviewFinalDetailDto> getInterviewFinalList(int pageNum, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+
+        return interviewGetService.getInterviewFinalList(pageable)
+                .getContent()
+                .stream()
+                .map(InterviewFinalDetailDto::from)
+                .toList();
     }
 
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -1,0 +1,37 @@
+package com.tave.tavewebsite.domain.interviewfinal.usecase;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFormInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
+import com.tave.tavewebsite.domain.interviewfinal.service.InterviewSaveService;
+import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
+import com.tave.tavewebsite.domain.member.service.AdminService;
+import com.tave.tavewebsite.domain.member.service.MemberService;
+import com.tave.tavewebsite.global.s3.service.S3DownloadSerivce;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewFinalUseCase {
+
+    private final InterviewExcelService interviewExcelService;
+    private final InterviewSaveService interviewSaveService;
+    private final S3DownloadSerivce s3DownloadSerivce;
+    private final MemberService memberService;
+
+    public InterviewFormInputStreamDto downloadInterviewFinal() throws IOException {
+        return s3DownloadSerivce.downloadInterviewFinalSetUpForm();
+    }
+
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -8,7 +8,6 @@ import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewSaveService;
 import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
-import com.tave.tavewebsite.domain.member.service.AdminService;
 import com.tave.tavewebsite.domain.member.service.MemberService;
 import com.tave.tavewebsite.global.s3.service.S3DownloadSerivce;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +62,7 @@ public class InterviewFinalUseCase {
     public List<InterviewFinalDetailDto> getInterviewFinalList(int pageNum, int pageSize) {
         Pageable pageable = PageRequest.of(pageNum, pageSize);
 
-        return interviewGetService.getInterviewFinalList(pageable)
+        return interviewGetService.getInterviewFinalPageableList(pageable)
                 .getContent()
                 .stream()
                 .map(InterviewFinalDetailDto::from)

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -34,4 +34,57 @@ public class InterviewFinalUseCase {
     }
 
 
+    public void insertInterviewEntityFromExcel(MultipartFile file) {
+        // Excel에서 최종 면접 데이터 추출
+        List<InterviewFinalConvertDto> dtoList = interviewExcelService.exportInterviewFinalFromExcel(file);
+
+        // Map <email, InterviewDto 객체>
+        Map<String, InterviewFinalConvertDto> mappingEmailInterviewFinal = dtoList.stream()
+                .collect(Collectors.toMap(InterviewFinalConvertDto::email, Function.identity()));
+
+        // SQL IN 조회를 위해 List<String> email 추출
+        List<String> emailList = mappingEmailInterviewFinal.keySet().stream().toList();
+
+        Integer generation = dtoList.get(0).generation();
+        List<MemberResumeDto> memberResumeDtoList = memberService.findMemberResumeDto(generation, emailList);
+
+        List<InterviewFinalSaveDto> pairedList = combineMemberResumeInterview(dtoList, memberResumeDtoList);
+
+        // BulkInsert
+        interviewSaveService.saveInterviewFinalList(pairedList);
+
+    }
+
+
+    /*
+    * refactor
+    * */
+
+    /*
+    * InterviewFinal을 저장할 때 추후 편리성을 위해 memberId와 resumeId를 같이 저장하고자 함.
+    * 이를 위해MemberResumeDto와 InterviewDto를 고유한 값 email + generation을 기준으로 결합.
+    * */
+    private List<InterviewFinalSaveDto> combineMemberResumeInterview(List<InterviewFinalConvertDto> dtoList, List<MemberResumeDto> memberResumeDtoList) {
+        return dtoList.stream()
+                .map(interviewDto -> {
+                    String email = interviewDto.email();
+
+                    // "분석 실패"인 경우
+                    if ("분석 실패".equals(email)) {
+                        return InterviewFinalSaveDto.analysisFailed(interviewDto);
+                    }
+
+                    // 정상 이메일인 경우: MemberResumeDto 찾기
+                    Optional<MemberResumeDto> matchedMember = memberResumeDtoList.stream()
+                            .filter(memberDto -> email.equals(memberDto.email()))
+                            .findFirst();
+
+                    // MemberResumeDto가 존재하면 success, 없으면 analysisFailed
+                    return matchedMember
+                            .map(memberDto -> InterviewFinalSaveDto.analysisSucceeded(interviewDto, memberDto))
+                            .orElseGet(() -> InterviewFinalSaveDto.analysisFailed(interviewDto));
+                })
+                .toList();
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/utils/ExcelUtils.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/utils/ExcelUtils.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.interviewfinal.utils;
 
 import com.tave.tavewebsite.domain.member.entity.Sex;
 import com.tave.tavewebsite.global.common.FieldType;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.springframework.stereotype.Component;
@@ -10,10 +11,11 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 
+@Slf4j
 @Component
 public class ExcelUtils {
 
-    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("M월 d일");
+    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("M/d");
     public static final String PARSING_NULL = "분석 실패";
     public static final String WEB_FRONTEND = "Web 프론트엔드";
     public static final String APP_FRONTEND = "App 프론트엔드";

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/utils/ExcelUtils.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/utils/ExcelUtils.java
@@ -1,0 +1,72 @@
+package com.tave.tavewebsite.domain.interviewfinal.utils;
+
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.FieldType;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.springframework.stereotype.Component;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+
+@Component
+public class ExcelUtils {
+
+    public static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("M월 d일");
+    public static final String PARSING_NULL = "분석 실패";
+    public static final String WEB_FRONTEND = "Web 프론트엔드";
+    public static final String APP_FRONTEND = "App 프론트엔드";
+    public static final String BACKEND = "백엔드";
+    public static final String DEEPLEARNING = "딥러닝";
+    public static final String DATAANALYSIST = "데이터분석";
+    public static final String DESIGN = "디자인";
+    public static final String MALE = "남자";
+    public static final String FEMALE = "여자";
+
+
+    public String getDayToCell(Cell cell) {
+        if (cell == null) return "";
+
+        Date day = cell.getDateCellValue();
+        return DATE_FORMAT.format(day);
+    }
+
+    public String getTimeToCell(Cell cell) {
+        return new DataFormatter().formatCellValue(cell);
+    }
+
+    public String getStringToCell(Cell cell) {
+        if (cell == null) return PARSING_NULL;
+        return cell.getStringCellValue().trim();
+    }
+
+    public Integer getIntegerToCell(Cell cell) {
+        Integer num = (int) cell.getNumericCellValue();
+        return num;
+    }
+
+    public Sex StringConvertToSex(String sex) {
+        return switch (sex) {
+            case PARSING_NULL -> Sex.NULL;
+            case MALE -> Sex.MALE;
+            case FEMALE -> Sex.FEMALE;
+            default -> Sex.NON_SEX;
+        };
+    }
+
+    public FieldType StringConvertToField(String field) {
+        if (field.equals(PARSING_NULL)) return FieldType.EXCEL_PARSING_NULL;
+
+        return switch (field.trim()) {
+            case BACKEND -> FieldType.BACKEND;
+            case DATAANALYSIST -> FieldType.DATAANALYSIS;
+            case DEEPLEARNING -> FieldType.DEEPLEARNING;
+            case WEB_FRONTEND -> FieldType.WEBFRONTEND;
+            case DESIGN -> FieldType.DESIGN;
+            case APP_FRONTEND -> FieldType.APPFRONTEND;
+            default -> FieldType.PARSING_NULL;
+        };
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.*;
+import static com.tave.tavewebsite.domain.interviewplace.controller.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/SuccessMessage.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.interviewplace.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    INTERVIEW_PLACE_GET("면접 장소 정보를 조회합니다"),
+    INTERVIEW_PLACE_CREATED("면접 장소 정보를 성공적으로 생성했습니다.");
+
+
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/MemberResumeDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/MemberResumeDto.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.member.dto.response;
+
+public record MemberResumeDto(
+        Long memberId,
+        Long resumeId,
+        String email
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
@@ -1,5 +1,15 @@
 package com.tave.tavewebsite.domain.member.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Sex {
-    MALE, FEMALE, NULL, NON_SEX
+    MALE("남자"),
+    FEMALE("여자"),
+    NULL("분석 실패"),
+    NON_SEX("분석 실패");
+
+    private final String displayName;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/entity/Sex.java
@@ -1,5 +1,5 @@
 package com.tave.tavewebsite.domain.member.entity;
 
 public enum Sex {
-    MALE, FEMALE
+    MALE, FEMALE, NULL, NON_SEX
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/memberRepository/MemberRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/memberRepository/MemberRepository.java
@@ -1,10 +1,13 @@
 package com.tave.tavewebsite.domain.member.memberRepository;
 
+import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.entity.RoleType;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +19,20 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String Nickname);
 
     Page<Member> findByRole(RoleType role, Pageable pageable);
+
+    @Query("""
+        SELECT new com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto(
+            m.id,          \s
+            r.id,          \s
+            m.email        \s
+        )
+        FROM Resume r
+        JOIN r.member m     \s
+        WHERE r.resumeGeneration = :generation
+          AND m.email IN :emails
+        \s""")
+    List<MemberResumeDto> findMemberIdAndResumeIdByGenAndEmails(
+            @Param("generation") Integer generation,
+            @Param("emails")     List<String> emails
+    );
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.tave.tavewebsite.domain.member.service;
 
 import com.tave.tavewebsite.domain.member.dto.request.*;
+import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.exception.DuplicateEmailException;
 import com.tave.tavewebsite.domain.member.exception.DuplicateNicknameException;
@@ -16,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -138,6 +141,10 @@ public class MemberService {
         }
 
         member.update(req.validatedPassword(), passwordEncoder);
+    }
+
+    public List<MemberResumeDto> findMemberResumeDto(Integer generation, List<String> email){
+        return memberRepository.findMemberIdAndResumeIdByGenAndEmails(generation, email);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/question/controller/QuestionController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/question/controller/QuestionController.java
@@ -65,4 +65,6 @@ public class QuestionController {
 
         return SuccessResponse.ok(QUESTION_DELETED.getMessage());
     }
+
+    // todo 질문 별로 순서 바꾸는 로직 필요함.
 }

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -6,19 +6,20 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FieldType {
-    DESIGN("Design"),
-    DEEPLEARNING("Deep Learning"),
-    DATAANALYSIS("Data Analysis"),
-    FRONTEND("Frontend"),
-    WEBFRONTEND("Web Frontend"),
-    APPFRONTEND("App Frontend"),
-    BACKEND("Backend"),
-    ADVANCED("Advanced"),       // 심화
-    COMMON("Common"),
-    COLLABORATIVE("Collaborative"),   // 연합
+    DESIGN("Design", "디자인"),
+    DEEPLEARNING("Deep Learning", "딥러닝"),
+    DATAANALYSIS("Data Analysis", "데이터분석"),
+    FRONTEND("Frontend", "프론트엔드"),
+    WEBFRONTEND("Web Frontend", "Web 프론트엔드"),
+    APPFRONTEND("App Frontend", "App 프론트엔드"),
+    BACKEND("Backend", "백엔드"),
+    ADVANCED("Advanced", "심화"),       // 심화
+    COMMON("Common", "공통"),
+    COLLABORATIVE("Collaborative", "연합"),   // 연합
 
-    EXCEL_PARSING_NULL("Parsing Error"),
-    PARSING_NULL("분석 실패");
+    EXCEL_PARSING_NULL("Parsing Error", "분석 에러"),
+    PARSING_NULL("분석 실패", "분석 실패");
 
     private final String message;
+    private final String displayName;
 }

--- a/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
+++ b/src/main/java/com/tave/tavewebsite/global/common/FieldType.java
@@ -15,7 +15,10 @@ public enum FieldType {
     BACKEND("Backend"),
     ADVANCED("Advanced"),       // 심화
     COMMON("Common"),
-    COLLABORATIVE("Collaborative");   // 연합
+    COLLABORATIVE("Collaborative"),   // 연합
+
+    EXCEL_PARSING_NULL("Parsing Error"),
+    PARSING_NULL("분석 실패");
 
     private final String message;
 }

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -1,0 +1,47 @@
+package com.tave.tavewebsite.global.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFormInputStreamDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class S3DownloadSerivce {
+
+    private final AmazonS3 s3Client;
+    private final String bucketName;
+    private final String finalInterviewBasicFormUrl;
+    private static final String FINAL_INTERVIEW_FORM_NAME = "최종 면접 시간표 설정 양식.xlsx";
+    private static final String HEADER_ATTACHMENT = "attachment";
+
+    public S3DownloadSerivce(AmazonS3 s3Client,@Value("${bucket_name}") String bucketName, @Value("${final_interview_form}") String finalInterviewBasicFormUrl) {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.finalInterviewBasicFormUrl = finalInterviewBasicFormUrl;
+    }
+
+    public InterviewFormInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
+
+        S3Object s3Object = s3Client.getObject(bucketName, finalInterviewBasicFormUrl);
+        S3ObjectInputStream inputStream = s3Object.getObjectContent();
+
+
+        HttpHeaders headers = new HttpHeaders();
+        ContentDisposition contentDisposition = ContentDisposition.builder(HEADER_ATTACHMENT)
+                .filename(FINAL_INTERVIEW_FORM_NAME, StandardCharsets.UTF_8)
+                .build();
+
+        headers.setContentDisposition(contentDisposition);
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE);
+
+        return InterviewFormInputStreamDto.from(inputStream, headers, s3Object.getObjectMetadata().getContentLength());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,9 @@ cloud:
     region:
       static: ${region}
 
+tavewebsite:
+  final_interview_form: ${FINAL_INTERVIEW_FORM}
+
 logging:
   level:
     org:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,8 +48,7 @@ cloud:
     region:
       static: ${region}
 
-tavewebsite:
-  final_interview_form: ${FINAL_INTERVIEW_FORM}
+final_interview_form: ${FINAL_INTERVIEW_FORM}
 
 logging:
   level:


### PR DESCRIPTION
## ➕ 연관된 이슈
> #132 
> Close #132 

## 📑 작업 내용
> - 이번 PR에서 작업한 내용 간략히 설명해주세요

- [ ] 최종 면접 정보 Entity 생성 (InterviewFinal)
- [ ] 최종 면접 정보 설정을 위한 양식 다운로드 API 구현
- [ ] 최종 면접 정보 Excel로부터 데이터를 추출 해 DB에 저장하는 API 구현
- [ ] 최종 면접 정보 페이지네이션 API 구현

## ✂️ 스크린샷 (선택)
>

추후 추가하도록 하겠습니다.

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


