### PR TITLE
feat: 최종 합격 안내 설정 기능 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -18,7 +18,7 @@ public class FinalPassController {
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
     }
 
-    @GetMapping("/v1/normal/final-pass")
+    @GetMapping("/v1/member/final-pass")
     public SuccessResponse<FinalPassResponseDto> getFinalPass() {
         FinalPassResponseDto dto = finalPassService.getFinalPass();
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -18,8 +18,8 @@ public class FinalPassController {
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
     }
 
-    @GetMapping("/v1/member/final-pass")
-    public SuccessResponse<FinalPassResponseDto> getFinalPassForMember() {
+    @GetMapping("/v1/normal/final-pass")
+    public SuccessResponse<FinalPassResponseDto> getFinalPass() {
         FinalPassResponseDto dto = finalPassService.getFinalPass();
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -18,12 +18,6 @@ public class FinalPassController {
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
     }
 
-    @GetMapping("/v1/admin/final-pass")
-    public SuccessResponse<FinalPassResponseDto> getFinalPass() {
-        FinalPassResponseDto dto = finalPassService.getFinalPass();
-        return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
-    }
-
     @GetMapping("/v1/member/final-pass")
     public SuccessResponse<FinalPassResponseDto> getFinalPassForMember() {
         FinalPassResponseDto dto = finalPassService.getFinalPass();

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -1,0 +1,28 @@
+package com.tave.tavewebsite.domain.finalpass.controller;
+
+import com.tave.tavewebsite.domain.finalpass.dto.request.FinalPassRequestDto;
+import com.tave.tavewebsite.domain.finalpass.dto.response.FinalPassResponseDto;
+import com.tave.tavewebsite.domain.finalpass.service.FinalPassService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/admin/final-pass")
+@RequiredArgsConstructor
+public class FinalPassController {
+    private final FinalPassService finalPassService;
+
+    @PostMapping
+    public SuccessResponse<FinalPassResponseDto> createFinalPass(@RequestBody FinalPassRequestDto requestDto) {
+        FinalPassResponseDto dto = finalPassService.createFinalPass(requestDto);
+        return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
+    }
+
+    @GetMapping
+    public SuccessResponse<FinalPassResponseDto> getFinalPass() {
+        FinalPassResponseDto dto = finalPassService.getFinalPass();
+        return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -8,21 +8,25 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/v1/admin/final-pass")
 @RequiredArgsConstructor
 public class FinalPassController {
     private final FinalPassService finalPassService;
 
-    @PostMapping
+    @PostMapping("/v1/admin/final-pass")
     public SuccessResponse<FinalPassResponseDto> createFinalPass(@RequestBody FinalPassRequestDto requestDto) {
         FinalPassResponseDto dto = finalPassService.createFinalPass(requestDto);
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
     }
 
-    @GetMapping
+    @GetMapping("/v1/admin/final-pass")
     public SuccessResponse<FinalPassResponseDto> getFinalPass() {
         FinalPassResponseDto dto = finalPassService.getFinalPass();
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
     }
 
+    @GetMapping("/v1/member/final-pass")
+    public SuccessResponse<FinalPassResponseDto> getFinalPassForMember() {
+        FinalPassResponseDto dto = finalPassService.getFinalPass();
+        return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassSuccessMessage.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.finalpass.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FinalPassSuccessMessage {
+    CREATE_FINAL_PASS("최종합격 안내 설정에 성공했습니다."),
+    READ_FINAL_PASS("최종합격 안내 조회에 성공했습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.finalpass.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,16 +11,37 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FinalPassRequestDto {
+    @NotNull(message = "총 회비 필수로 입력해주세요.")
     private Integer totalFee;
+
     private Integer clubFee;
+
     private Integer mtFee;
+
+    @NotNull(message = "회비 납부 마감기한 필수로 입력해주세요.")
     private LocalDate feeDeadline;
+
+    @NotNull(message = "은행명 필수로 입력해주세요.")
     private String bankName;
+
+    @NotNull(message = "계좌번호 필수로 입력해주세요.")
     private String accountNumber;
+
+    @NotNull(message = "예금주 필수로 입력해주세요.")
     private String accountHolder;
+
+    @NotNull(message = "아지트 초대 설문 조사 링크 필수로 입력해주세요.")
     private String surveyLink;
+
+    @NotNull(message = "아지트 초대 설문 조사 마감기한 필수로 입력해주세요.")
     private LocalDate surveyDeadline;
+
+    @NotNull(message = "OT 공지방 링크 필수로 입력해주세요.")
     private String otLink;
+
+    @NotNull(message = "OT 공지방 비밀번호 필수로 입력해주세요.")
     private String otPassword;
+
+    @NotNull(message = "OT 마감기한 필수로 입력해주세요. ")
     private LocalDate otDeadline;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
@@ -1,0 +1,25 @@
+package com.tave.tavewebsite.domain.finalpass.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinalPassRequestDto {
+    private Integer totalFee;
+    private Integer clubFee;
+    private Integer mtFee;
+    private LocalDate feeDeadline;
+    private String bankName;
+    private String accountNumber;
+    private String accountHolder;
+    private String surveyLink;
+    private LocalDate surveyDeadline;
+    private String otLink;
+    private String otPassword;
+    private LocalDate otDeadline;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
@@ -1,6 +1,6 @@
 package com.tave.tavewebsite.domain.finalpass.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,36 +12,48 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class FinalPassRequestDto {
     @NotNull(message = "총 회비 필수로 입력해주세요.")
+    @Positive(message = "총 회비는 0보다 커야 합니다.")
     private Integer totalFee;
 
+    @Positive(message = "동아리 회비는 0보다 커야 합니다.")
     private Integer clubFee;
 
+    @Positive(message = "MT 회비는 0보다 커야 합니다.")
     private Integer mtFee;
 
     @NotNull(message = "회비 납부 마감기한 필수로 입력해주세요.")
+    @FutureOrPresent(message = "회비 납부 마감기한은 오늘 또는 미래여야 합니다.")
     private LocalDate feeDeadline;
 
-    @NotNull(message = "은행명 필수로 입력해주세요.")
+    @NotBlank(message = "은행명 필수로 입력해주세요.")
+    @Size(max = 10, message = "은행명은 10자 이하로 입력해주세요.")
     private String bankName;
 
-    @NotNull(message = "계좌번호 필수로 입력해주세요.")
+    @NotBlank(message = "계좌번호 필수로 입력해주세요.")
+    @Size(max = 30, message = "계좌번호는 30자 이하로 입력해주세요.")
     private String accountNumber;
 
-    @NotNull(message = "예금주 필수로 입력해주세요.")
+    @NotBlank(message = "예금주 필수로 입력해주세요.")
+    @Size(max = 30, message = "예금주는 30자 이하로 입력해주세요.")
     private String accountHolder;
 
-    @NotNull(message = "아지트 초대 설문 조사 링크 필수로 입력해주세요.")
+    @NotBlank(message = "아지트 초대 설문 조사 링크 필수로 입력해주세요.")
+    @Size(max = 200, message = "링크는 200자 이하로 입력해주세요.")
     private String surveyLink;
 
     @NotNull(message = "아지트 초대 설문 조사 마감기한 필수로 입력해주세요.")
+    @FutureOrPresent(message = "설문 마감기한은 오늘 또는 미래여야 합니다.")
     private LocalDate surveyDeadline;
 
-    @NotNull(message = "OT 공지방 링크 필수로 입력해주세요.")
+    @NotBlank(message = "OT 공지방 링크 필수로 입력해주세요.")
+    @Size(max = 200, message = "링크는 200자 이하로 입력해주세요.")
     private String otLink;
 
-    @NotNull(message = "OT 공지방 비밀번호 필수로 입력해주세요.")
+    @NotBlank(message = "OT 공지방 비밀번호 필수로 입력해주세요.")
+    @Size(max = 20, message = "비밀번호는 20자 이하로 입력해주세요.")
     private String otPassword;
 
     @NotNull(message = "OT 마감기한 필수로 입력해주세요. ")
+    @FutureOrPresent(message = "OT 마감기한은 오늘 또는 미래여야 합니다.")
     private LocalDate otDeadline;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/response/FinalPassResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/response/FinalPassResponseDto.java
@@ -1,0 +1,25 @@
+package com.tave.tavewebsite.domain.finalpass.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class FinalPassResponseDto {
+
+    private Long id;
+    private Integer totalFee;
+    private Integer clubFee;
+    private Integer mtFee;
+    private LocalDate feeDeadline;
+    private String bankName;
+    private String accountNumber;
+    private String accountHolder;
+    private String surveyLink;
+    private LocalDate surveyDeadline;
+    private String otLink;
+    private String otPassword;
+    private LocalDate otDeadline;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
@@ -1,0 +1,67 @@
+package com.tave.tavewebsite.domain.finalpass.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FinalPass {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 회비
+    @NotNull
+    @Column(nullable = false)
+    private Integer totalFee;
+
+    private Integer clubFee;
+
+    private Integer mtFee;
+
+    @NotNull
+    @Column(nullable = false, length = 30)
+    private String bankName;
+
+    @NotNull
+    @Column(nullable = false, length = 50)
+    private String accountNumber;
+
+    @NotNull
+    @Column(nullable = false, length = 30)
+    private String accountHolder;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDate feeDeadline;
+
+    // 아지트 초대 설문 조사
+    @NotNull
+    @Column(nullable = false)
+    private String surveyLink;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDate surveyDeadline;
+
+    // OT 공지방
+    @NotNull
+    @Column(nullable = false)
+    private String otLink;
+
+    @NotNull
+    @Column(nullable = false)
+    private String otPassword;
+
+    @NotNull
+    @Column(nullable = false)
+    private LocalDate otDeadline;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/exception/ErrorMessage.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.finalpass.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+    FINAL_PASS_NOT_FOUND(404, "최종 합격 안내 정보가 존재하지 않습니다.");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/exception/FinalPassNotFoundException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/exception/FinalPassNotFoundException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.finalpass.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.finalpass.exception.ErrorMessage.FINAL_PASS_NOT_FOUND;
+
+public class FinalPassNotFoundException extends BaseErrorException {
+    public FinalPassNotFoundException() {
+        super(FINAL_PASS_NOT_FOUND.getCode(), FINAL_PASS_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/mapper/FinalPassMapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/mapper/FinalPassMapper.java
@@ -1,0 +1,58 @@
+package com.tave.tavewebsite.domain.finalpass.mapper;
+
+import com.tave.tavewebsite.domain.finalpass.dto.request.FinalPassRequestDto;
+import com.tave.tavewebsite.domain.finalpass.dto.response.FinalPassResponseDto;
+import com.tave.tavewebsite.domain.finalpass.entity.FinalPass;
+
+public class FinalPassMapper {
+
+    public static FinalPass toEntity(FinalPassRequestDto dto) {
+        return FinalPass.builder()
+                .totalFee(dto.getTotalFee())
+                .clubFee(dto.getClubFee())
+                .mtFee(dto.getMtFee())
+                .feeDeadline(dto.getFeeDeadline())
+                .bankName(dto.getBankName())
+                .accountNumber(dto.getAccountNumber())
+                .accountHolder(dto.getAccountHolder())
+                .surveyLink(dto.getSurveyLink())
+                .surveyDeadline(dto.getSurveyDeadline())
+                .otLink(dto.getOtLink())
+                .otPassword(dto.getOtPassword())
+                .otDeadline(dto.getOtDeadline())
+                .build();
+    }
+
+    public static FinalPassResponseDto toResponseDto(FinalPass entity) {
+        return FinalPassResponseDto.builder()
+                .id(entity.getId())
+                .totalFee(entity.getTotalFee())
+                .clubFee(entity.getClubFee())
+                .mtFee(entity.getMtFee())
+                .feeDeadline(entity.getFeeDeadline())
+                .bankName(entity.getBankName())
+                .accountNumber(entity.getAccountNumber())
+                .accountHolder(entity.getAccountHolder())
+                .surveyLink(entity.getSurveyLink())
+                .surveyDeadline(entity.getSurveyDeadline())
+                .otLink(entity.getOtLink())
+                .otPassword(entity.getOtPassword())
+                .otDeadline(entity.getOtDeadline())
+                .build();
+    }
+
+    public static void updateEntity(FinalPass entity, FinalPassRequestDto dto) {
+        entity.setTotalFee(dto.getTotalFee());
+        entity.setClubFee(dto.getClubFee());
+        entity.setMtFee(dto.getMtFee());
+        entity.setFeeDeadline(dto.getFeeDeadline());
+        entity.setBankName(dto.getBankName());
+        entity.setAccountNumber(dto.getAccountNumber());
+        entity.setAccountHolder(dto.getAccountHolder());
+        entity.setSurveyLink(dto.getSurveyLink());
+        entity.setSurveyDeadline(dto.getSurveyDeadline());
+        entity.setOtLink(dto.getOtLink());
+        entity.setOtPassword(dto.getOtPassword());
+        entity.setOtDeadline(dto.getOtDeadline());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/repository/FinalPassRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/repository/FinalPassRepository.java
@@ -1,0 +1,10 @@
+package com.tave.tavewebsite.domain.finalpass.repository;
+
+import com.tave.tavewebsite.domain.finalpass.entity.FinalPass;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FinalPassRepository extends JpaRepository<FinalPass, Long> {
+    Optional<FinalPass> findTopBy();
+}

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
@@ -22,7 +22,6 @@ public class FinalPassService {
         return FinalPassMapper.toResponseDto(entity);
     }
 
-    @Transactional
     public FinalPassResponseDto getFinalPass() {
         FinalPass entity = finalPassRepository.findTopBy()
                 .orElseThrow(FinalPassNotFoundException::new);

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
@@ -1,0 +1,32 @@
+package com.tave.tavewebsite.domain.finalpass.service;
+
+import com.tave.tavewebsite.domain.finalpass.dto.request.FinalPassRequestDto;
+import com.tave.tavewebsite.domain.finalpass.dto.response.FinalPassResponseDto;
+import com.tave.tavewebsite.domain.finalpass.entity.FinalPass;
+import com.tave.tavewebsite.domain.finalpass.exception.FinalPassNotFoundException;
+import com.tave.tavewebsite.domain.finalpass.mapper.FinalPassMapper;
+import com.tave.tavewebsite.domain.finalpass.repository.FinalPassRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FinalPassService {
+    private final FinalPassRepository finalPassRepository;
+
+    @Transactional
+    public FinalPassResponseDto createFinalPass(FinalPassRequestDto dto) {
+        FinalPass entity = FinalPassMapper.toEntity(dto);
+        finalPassRepository.save(entity);
+        return FinalPassMapper.toResponseDto(entity);
+    }
+
+    @Transactional
+    public FinalPassResponseDto getFinalPass() {
+        FinalPass entity = finalPassRepository.findTopBy()
+                .orElseThrow(FinalPassNotFoundException::new);
+        return FinalPassMapper.toResponseDto(entity);
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #138
> Close #138

## 📑 작업 내용
> - admin 권한으로 최종 합격 안내 설정 api 구현했습니다.
> - member 권한으로 최종 합격 안내 조회 api 구현했습니다.
> - Entity와 DTO 간 변환 로직을 FinalPassMapper에 집중시켜 코드 중복을 최소화하고자 했습니다.
> - 수동 변환 대신 Mapper를 사용해 가독성 향상 및 변환 오류 가능성을 감소시켰습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
