### PR TITLE
[feat] BulkInsert SQL에 answer_type과 text_length 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeQuestionJdbcRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeQuestionJdbcRepository.java
@@ -22,8 +22,8 @@ public class ResumeQuestionJdbcRepository {
 
         // INSERT 쿼리
         String sql = """
-            INSERT INTO resume_question (question, answer, ordered, resume_id, field_type, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, NOW(), NOW())
+            INSERT INTO resume_question (question, answer, ordered, resume_id, field_type, answer_type, text_length ,created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
         """;
 
         return jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
@@ -39,6 +39,8 @@ public class ResumeQuestionJdbcRepository {
                 }
                 ps.setLong(4, resume.getId());
                 ps.setString(5, resumeQuestion.getFieldType().name());
+                ps.setString(6, resumeQuestion.getAnswerType().name());
+                ps.setInt(7, resumeQuestion.getTextLength());
             }
 
             @Override


### PR DESCRIPTION
## ➕ 연관된 이슈
> #153 
> Close #153

## 📑 작업 내용
> - Resume을 저장할 때 생성되는 ResumeQuestion에 answer_type과 text_length가 저장되지 않는 오류 해결

ResumeQuestion은 성능 향상을 위해 JdbcTemplate을 활용한 BulkInsert를 사용합니다.
작업 중간에 answer_type과 text_length가 추가되었는데 이를 JdbcTemplate bulkinsert sql에도 추가하지 못해 발생한 오류 입니다.

다음과 같이 answer_type과 text_length를 추가해 정상적으로 동작하게 수정했습니다.
```java
String sql = """
    INSERT INTO resume_question (question, answer, ordered, resume_id, field_type, answer_type, text_length ,created_at, updated_at)
    VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
""";
```

## ✂️ 스크린샷 (선택)
>

### Resume 생성 테스트 후 DB 확인

![image](https://github.com/user-attachments/assets/dbccd208-d4f3-41b5-a32d-7d5b2c9bcde6)


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
