### PR TITLE
[Feat] 전송 실패한 이메일 관련 dlq 로직 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/EmailNotificationSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/EmailNotificationSuccessMessage.java
@@ -7,7 +7,8 @@ public enum EmailNotificationSuccessMessage {
     POST_SUCCESS("이메일 알림 신청에 성공했습니다."),
     GET_SUCCESS("신규 회원 모집 알림 신청자 조회에 성공했습니다."),
     APPLY_EMAIL_SEND_SUCCESS("신규 회원 모집 알림 이메일 전송이 완료되었습니다."),
-    APPLY_EMAIL_BATCH_JOB_RESERVE("신규 회원 모집 알림 이메일 발송 설정이 완료되었습니다. 작업은 03:00에 실행됩니다.");
+    APPLY_EMAIL_BATCH_JOB_RESERVE("신규 회원 모집 알림 이메일 발송 설정이 완료되었습니다. 작업은 03:00에 실행됩니다."),
+    DELETE_APPLY_EMAIL_BATCH_JOB_RESERVE("신규 회원 모집 알림 이메일 발송을 취소했습니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/NormalEmailNotificationController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/controller/NormalEmailNotificationController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +35,12 @@ public class NormalEmailNotificationController {
     public SuccessResponse sendEmailBatch() {
         emailNotificationService.setSchedulerOfApplyNotificationEmail();
         return SuccessResponse.ok(EmailNotificationSuccessMessage.APPLY_EMAIL_BATCH_JOB_RESERVE.getMessage());
+    }
+
+    @DeleteMapping("/admin/notification/reservation")
+    public SuccessResponse deleteEmailBatch() {
+        emailNotificationService.cancelTodayAndTomorrowApplyNotificationSchedule();
+        return SuccessResponse.ok(EmailNotificationSuccessMessage.DELETE_APPLY_EMAIL_BATCH_JOB_RESERVE.getMessage());
     }
 
     @GetMapping("/admin/notification/individual/{id}")

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailNotificationDLQ.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/entity/EmailNotificationDLQ.java
@@ -1,0 +1,48 @@
+package com.tave.tavewebsite.domain.emailnotification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailNotificationDLQ {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    @Lob  // TEXT 필드로 저장
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    private LocalDateTime failedAt;
+
+    public static EmailNotificationDLQ from(EmailNotification source, Throwable e) {
+        EmailNotificationDLQ dlq = new EmailNotificationDLQ();
+        dlq.email = source.getEmail();
+        dlq.errorMessage = stackTraceToString(e);
+        dlq.failedAt = LocalDateTime.now();
+        return dlq;
+    }
+
+    private static String stackTraceToString(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        throwable.printStackTrace(pw);
+        return sw.toString();
+    }
+}
+

--- a/src/main/java/com/tave/tavewebsite/domain/emailnotification/repository/EmailNotificationDLQRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/emailnotification/repository/EmailNotificationDLQRepository.java
@@ -1,0 +1,9 @@
+package com.tave.tavewebsite.domain.emailnotification.repository;
+
+import com.tave.tavewebsite.domain.emailnotification.entity.EmailNotificationDLQ;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EmailNotificationDLQRepository extends JpaRepository<EmailNotificationDLQ, Long> {
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #149 
> Close #149 

## 📑 작업 내용
> - 전송에 성공한 이메일은 기존 테이블에서 삭제시켰습니다. deleteAllByIdInBatch를 사용해 벌크 연산을 적용했습니다.
> - 전송에 실패한 이메일은 기존 테이블에서 삭제시킨 후 dlq로 이동 시켰습니다.
> - 이메일 발송 예약 취소 로직을 추가했습니다. (redis에 저장된 예약 발송 키를 삭제하는 로직입니다.)
