### PR TITLE
[Feat] interviewplace 조회 API 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/controller/InterviewPlaceController.java
@@ -1,10 +1,12 @@
 package com.tave.tavewebsite.domain.interviewplace.controller;
 
 import com.tave.tavewebsite.domain.interviewplace.dto.request.InterviewPlaceSaveDto;
+import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceDetailDto;
 import com.tave.tavewebsite.domain.interviewplace.service.InterviewPlaceService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +28,13 @@ public class InterviewPlaceController {
 
         return new SuccessResponse<>(INTERVIEW_PLACE_CREATED.getMessage());
     }
+
+    @GetMapping("/v1/manager/interview-place")
+    public SuccessResponse<List<InterviewPlaceDetailDto>> getInterviewPlaceList() {
+        List<InterviewPlaceDetailDto> response = interviewPlaceService.getInterviewPlaceList();
+
+        return new SuccessResponse<>(response, INTERVIEW_PLACE_GET.getMessage());
+    }
+
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewplace/service/InterviewPlaceService.java
@@ -29,6 +29,12 @@ public class InterviewPlaceService {
         interviewPlaceRepository.saveAll(saveList);
     }
 
+    public List<InterviewPlaceDetailDto> getInterviewPlaceList() {
+        return getInterviewPlaceActiveList().stream()
+                .map(InterviewPlaceDetailDto::of)
+                .toList();
+    }
+
     private List<InterviewPlace> getInterviewPlaceActiveList() {
         return interviewPlaceRepository.findByStatus(Status.ACTIVE);
     }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #184
> Close #184

## 📑 작업 내용
> - InterviewPlace 조회 API를 구현합니다.

## API 엔드포인트

EndPoint: "/v1/manager/interview-place"

## ✂️ 응답 JSON(선택)
> 

```json
{
    "time": "2025-06-25T23:20:42.4684869",
    "status": 200,
    "code": "200",
    "message": "면접 장소 정보를 조회합니다",
    "result": [
        {
            "id": 7,
            "interviewDay": "2025-08-11",
            "generalAddress": "서울시 중구 을지로 100",
            "detailAddress": "우랄랄ㄹ라1",
            "openChatLink": "https://open.kakao.com/o/somechat",
            "code": "A1BDD"
        },
        {
            "id": 8,
            "interviewDay": "2025-08-12",
            "generalAddress": "서울시 중구 을지로 100",
            "detailAddress": "우랄랄ㄹ라2",
            "openChatLink": "https://open.kakao.com/o/anotherchat",
            "code": "B332"
        },
        {
            "id": 9,
            "interviewDay": "2025-08-13",
            "generalAddress": "서울시 중구 을지로 100",
            "detailAddress": "우랄랄ㄹ라3",
            "openChatLink": "https://open.kakao.com/o/somechat",
            "code": "A1BD"
        }
    ]
}
```

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
