### PR TITLE
feat: 최종제출 여부 필드 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/controller/AuthController.java
@@ -52,7 +52,7 @@ public class AuthController {
 
     @GetMapping("/auth/signout")
     public SuccessResponse signOut(@RequestHeader("Authorization") String token, HttpServletResponse response) {
-        authService.singOut(token, response);
+        authService.signOut(token, response);
         return SuccessResponse.ok(MemberSuccessMessage.SIGN_OUT_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.member.dto.response;
 import com.tave.tavewebsite.domain.member.entity.DepartmentType;
 import com.tave.tavewebsite.domain.member.entity.JobType;
 import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.resume.entity.ResumeState;
 import com.tave.tavewebsite.global.security.entity.JwtToken;
 
 public record SignInResponseDto(
@@ -16,9 +17,9 @@ public record SignInResponseDto(
         String generation,
         DepartmentType department,
         JobType job,
-        boolean isSubmitted
+        ResumeState resumeState
 ) {
-    public static SignInResponseDto from(JwtToken token, Member member, boolean isSubmitted) {
+    public static SignInResponseDto from(JwtToken token, Member member, ResumeState resumeState) {
         return new SignInResponseDto(token.getGrantType(),
                 token.getAccessToken(),
                 member.getId(),
@@ -29,6 +30,6 @@ public record SignInResponseDto(
                 member.getGeneration(),
                 member.getDepartment(),
                 member.getJob(),
-                isSubmitted);
+                resumeState);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
@@ -15,9 +15,10 @@ public record SignInResponseDto(
         String agitId,
         String generation,
         DepartmentType department,
-        JobType job
+        JobType job,
+        boolean isSubmitted
 ) {
-    public static SignInResponseDto from(JwtToken token, Member member) {
+    public static SignInResponseDto from(JwtToken token, Member member, boolean isSubmitted) {
         return new SignInResponseDto(token.getGrantType(),
                 token.getAccessToken(),
                 member.getId(),
@@ -27,6 +28,7 @@ public record SignInResponseDto(
                 member.getAgitId(),
                 member.getGeneration(),
                 member.getDepartment(),
-                member.getJob());
+                member.getJob(),
+                isSubmitted);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -8,6 +8,7 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.exception.NotFoundMemberException;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.entity.ResumeState;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import com.tave.tavewebsite.global.security.entity.JwtToken;
@@ -46,11 +47,10 @@ public class AuthService {
         Member member = memberRepository.findByEmail(requestDto.email())
                 .orElseThrow(NotFoundMemberException::new);
 
-        boolean isSubmitted = resumeRepository.findByMemberId(member.getId())
-                .map(Resume::isSubmitted)
-                .orElse(false);
-
-        return SignInResponseDto.from(jwtToken, member, isSubmitted);
+        ResumeState resumeState = resumeRepository.findByMemberId(member.getId())
+                .map(Resume::getState)
+                .orElse(ResumeState.TEMPORARY);
+        return SignInResponseDto.from(jwtToken, member, resumeState);
     }
 
     public void signOut(String accessToken, HttpServletResponse response) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -4,27 +4,17 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
-import com.tave.tavewebsite.domain.resume.exception.AlreadySubmittedResumeException;
 import com.tave.tavewebsite.global.common.BaseEntity;
 import com.tave.tavewebsite.global.common.FieldType;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Size;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -133,11 +123,15 @@ public class Resume extends BaseEntity {
         this.portfolioUrl = portfolioUrl;
     }
 
-    public void submit() {
-        if (this.state == ResumeState.SUBMITTED) {
-            throw new AlreadySubmittedResumeException();
-        }
-        this.state = ResumeState.SUBMITTED;
+//    public void submit() {
+//        if (this.state == ResumeState.SUBMITTED) {
+//            throw new AlreadySubmittedResumeException();
+//        }
+//        this.state = ResumeState.SUBMITTED;
+//    }
+
+    public boolean isSubmitted() {
+        return this.state == ResumeState.SUBMITTED;
     }
 
     public void updateFinalDocumentEvaluationStatus(EvaluationStatus finalDocumentEvaluationStatus) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
+import com.tave.tavewebsite.domain.resume.exception.AlreadySubmittedResumeException;
 import com.tave.tavewebsite.global.common.BaseEntity;
 import com.tave.tavewebsite.global.common.FieldType;
 import jakarta.persistence.*;
@@ -123,12 +124,12 @@ public class Resume extends BaseEntity {
         this.portfolioUrl = portfolioUrl;
     }
 
-//    public void submit() {
-//        if (this.state == ResumeState.SUBMITTED) {
-//            throw new AlreadySubmittedResumeException();
-//        }
-//        this.state = ResumeState.SUBMITTED;
-//    }
+    public void submit() {
+        if (this.state == ResumeState.SUBMITTED) {
+            throw new AlreadySubmittedResumeException();
+        }
+        this.state = ResumeState.SUBMITTED;
+    }
 
     public boolean isSubmitted() {
         return this.state == ResumeState.SUBMITTED;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeState.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/ResumeState.java
@@ -2,5 +2,5 @@ package com.tave.tavewebsite.domain.resume.entity;
 
 public enum ResumeState {
     TEMPORARY, // 임시저장
-    SUBMITTED, // 제출완료
+    SUBMITTED // 제출완료
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #181 
> Close #181 

## 📑 작업 내용
> - 로그인 시 최종제출 여부 확인할 수 있는 필드 `resumeState` 를 추가했습니다.
> - `ResumeRepository`에서 `Optional<Resume>` 반환에 따른 `AuthService`의 Optional 처리 로직을 적용했습니다.
> - JWT 토큰 생성과 쿠키 세팅 로직을 한 번만 수행하도록 개선했습니다.

## ✂️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/47416d40-e095-43e4-a4dc-d70750a62962)
<img src="https://github.com/user-attachments/assets/c87cdc82-08cb-4dfa-be1b-69d0430722da" width="400" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
