### PR TITLE
[Feat] TEST-CI-CD.yml 작성

### DIFF
--- a/.github/workflows/TEST-CI-CD.yml
+++ b/.github/workflows/TEST-CI-CD.yml
@@ -1,0 +1,75 @@
+name: Java CI/CD with Gradle
+
+# 워크플로우가 실행될 조건을 정의합니다.
+on:
+  push:
+    branches: [ "main" ] # main 브랜치에 push가 발생하면 실행됩니다.
+
+# 워크플로우가 접근할 수 있는 권한을 설정합니다.
+permissions:
+  contents: read
+
+jobs:
+  # Docker 이미지를 빌드하고 Docker Hub에 푸시하는 작업을 정의합니다.
+  build-docker-image:
+    runs-on: ubuntu-latest # 워크플로우가 실행될 환경을 지정합니다.
+    steps:
+      # 리포지토리의 코드를 체크아웃합니다.
+      - uses: actions/checkout@v3
+
+      # JDK 17을 설치하고 환경을 설정합니다.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Gradle Wrapper 파일에 실행 권한을 부여합니다.
+      - name: Grant Execute Permission For Gradlew
+        run: chmod +x gradlew
+
+      # gradle caching - 빌드 시간 향상
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # Gradle을 사용하여 프로젝트를 빌드합니다.
+      - name: Build With Gradle
+        run: ./gradlew build -x test
+
+      # Docker 이미지를 빌드합니다.
+      - name: docker image build
+        run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/tavewebsite-test .
+
+      # Docker Hub에 로그인합니다. 로그인 정보는 GitHub Secrets를 통해 안전하게 관리됩니다.
+      - name: docker login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }} # Docker Hub 사용자 이름
+          password: ${{ secrets.DOCKERHUB_PASSWORD }} # Docker Hub 비밀번호
+
+      # 빌드된 Docker 이미지를 Docker Hub에 푸시합니다.
+      - name: docker Hub push
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/tavewebsite-test
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    steps:
+      # SSH를 사용하여 원격 서버에 배포
+      - name: Deploy to server
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.TEST_SSH_HOST }}
+          username: ${{ secrets.TEST_SSH_USER }}
+          port: 22
+          key: ${{ secrets.TEST_SSH_SECRET_PRIVATE_KEY }}
+          script: |
+            sudo /home/ec2-user/deploy.sh


### PR DESCRIPTION
## ➕ 연관된 이슈
> #189
> Close #189

## 📑 작업 내용
> - 

Test서버에 Main 브랜치 작업을 반영하기 위해 CI-CD 파이프라인을 구축했습니다.

실제 서버와 달리 ASG를 사용하지 않기 때문에 EC2서버 내부에 deploy.sh 스크립트를 작성 후 실행하도록 했습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
