### PR TITLE
fix: 개인 정보 및 질문 생성 트랜잭션 통합으로 롤백 문제 해결

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -21,7 +21,7 @@ import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessM
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/v1/member/info")
+@RequestMapping("/v1/normal/info")
 public class PersonalInfoController {
 
     private final PersonalInfoService personalInfoService;
@@ -31,17 +31,26 @@ public class PersonalInfoController {
     public SuccessResponse<CreatePersonalInfoResponse> createPersonalInfoWithQuestions(
             @PathVariable("memberId") Long memberId,
             @RequestBody @Valid PersonalInfoCreateRequestDto requestDto) {
-        Resume resume = personalInfoService.createPersonalInfo(memberId, requestDto);
-        ResumeQuestionResponse questions = personalInfoService.createResumeQuestions(resume);
 
-        CreatePersonalInfoResponse response = CreatePersonalInfoResponse.of(
-                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(),
-                questions,
-                resume.getId()
-        );
-
+        CreatePersonalInfoResponse response = personalInfoService.createPersonalInfoAndQuestions(memberId, requestDto);
         return new SuccessResponse<>(response, PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
     }
+
+//    @PostMapping("/{memberId}")
+//    public SuccessResponse<CreatePersonalInfoResponse> createPersonalInfoWithQuestions(
+//            @PathVariable("memberId") Long memberId,
+//            @RequestBody @Valid PersonalInfoCreateRequestDto requestDto) {
+//        Resume resume = personalInfoService.createPersonalInfo(memberId, requestDto);
+//        ResumeQuestionResponse questions = personalInfoService.createResumeQuestions(resume);
+//
+//        CreatePersonalInfoResponse response = CreatePersonalInfoResponse.of(
+//                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(),
+//                questions,
+//                resume.getId()
+//        );
+//
+//        return new SuccessResponse<>(response, PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage());
+//    }
 
     // 전체 개인정보 조회
     @GetMapping("/{memberId}")

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/PersonalInfoController.java
@@ -21,7 +21,7 @@ import static com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessM
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/v1/normal/info")
+@RequestMapping("/v1/member/info")
 public class PersonalInfoController {
 
     private final PersonalInfoService personalInfoService;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -1,6 +1,5 @@
 package com.tave.tavewebsite.domain.resume.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tave.tavewebsite.domain.applicant.history.entity.ApplicantHistory;
 import com.tave.tavewebsite.domain.applicant.history.entity.ApplicationStatus;
 import com.tave.tavewebsite.domain.applicant.history.repository.ApplicantHistoryRepository;
@@ -11,8 +10,10 @@ import com.tave.tavewebsite.domain.programinglaunguage.entity.ProgramingLanguage
 import com.tave.tavewebsite.domain.programinglaunguage.repository.LanguageLevelRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.repository.ProgramingLanguageRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.util.LanguageLevelMapper;
+import com.tave.tavewebsite.domain.resume.controller.PersonalInfoSuccessMessage;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoCreateRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.request.PersonalInfoRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.CreatePersonalInfoResponse;
 import com.tave.tavewebsite.domain.resume.dto.response.DetailResumeQuestionResponse;
 import com.tave.tavewebsite.domain.resume.dto.response.PersonalInfoResponseDto;
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeQuestionResponse;
@@ -48,7 +49,18 @@ public class PersonalInfoService {
     private final ResumeQuestionRepository resumeQuestionRepository;
 
     private final RedisUtil redisUtil;
-    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public CreatePersonalInfoResponse createPersonalInfoAndQuestions(Long memberId, PersonalInfoCreateRequestDto requestDto) {
+        Resume resume = createPersonalInfo(memberId, requestDto);
+        ResumeQuestionResponse questions = createResumeQuestions(resume);
+
+        return CreatePersonalInfoResponse.of(
+                PersonalInfoSuccessMessage.CREATE_SUCCESS.getMessage(),
+                questions,
+                resume.getId()
+        );
+    }
 
     @Transactional
     public Resume createPersonalInfo(Long memberId, PersonalInfoCreateRequestDto requestDto) {


### PR DESCRIPTION
## ➕ 연관된 이슈
> #201
> Close #201

## 📑 작업 내용
> - 지원서 생성과 질문 생성 로직을 하나의 트랜잭션으로 통합하여 처리했습니다.
> - `createPersonalInfoAndQuestions()` 메서드 추가 및 기존 메서드 호출 구조를 변경했습니다.
> - 질문 생성 과정에서 예외 발생 시, 이력서 생성도 함께 롤백되도록 개선했습니다.
> - `@Transactional `범위 확장으로 데이터 일관성 및 원자성을 보장하도록 했습니다.
> - 컨트롤러에서 서비스 호출 부분 수정하여 트랜잭션 통합을 반영했습니다.

## ✂️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/29354e68-9470-4c95-803c-3e6055601cb7)

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
