### PR TITLE
feat: 지원서 리스트 조회 기능 및 공통/분야별 응답 DTO 분리 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
@@ -1,5 +1,7 @@
 package com.tave.tavewebsite.domain.resume.dto.response;
 
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+
 import java.util.List;
 
 public record CommonResumeResponse(
@@ -9,11 +11,14 @@ public record CommonResumeResponse(
         String portfolioUrl,
         List<DetailResumeQuestionResponse> commonQuestions
 ) {
-    public static CommonResumeResponse of(Long resumeId,
-                                          String blogUrl,
-                                          String githubUrl,
-                                          String portfolioUrl,
+    public static CommonResumeResponse of(Resume resume,
                                           List<DetailResumeQuestionResponse> commonQuestions) {
-        return new CommonResumeResponse(resumeId, blogUrl, githubUrl, portfolioUrl, commonQuestions);
+        return new CommonResumeResponse(
+                resume.getId(),
+                resume.getBlogUrl(),
+                resume.getGithubUrl(),
+                resume.getPortfolioUrl(),
+                commonQuestions
+        );
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
@@ -1,0 +1,19 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import java.util.List;
+
+public record CommonResumeResponse(
+        Long resumeId,
+        String blogUrl,
+        String githubUrl,
+        String portfolioUrl,
+        List<DetailResumeQuestionResponse> commonQuestions
+) {
+    public static CommonResumeResponse of(Long resumeId,
+                                          String blogUrl,
+                                          String githubUrl,
+                                          String portfolioUrl,
+                                          List<DetailResumeQuestionResponse> commonQuestions) {
+        return new CommonResumeResponse(resumeId, blogUrl, githubUrl, portfolioUrl, commonQuestions);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeListResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeListResponse.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import java.util.List;
+
+public record ResumeListResponse(
+        List<CommonResumeResponse> common,
+        List<SpecificResumeResponseDto> specific
+) {
+    public static ResumeListResponse of(List<CommonResumeResponse> common, List<SpecificResumeResponseDto> specific) {
+        return new ResumeListResponse(common, specific);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeListResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeListResponse.java
@@ -3,10 +3,9 @@ package com.tave.tavewebsite.domain.resume.dto.response;
 import java.util.List;
 
 public record ResumeListResponse(
-        List<CommonResumeResponse> common,
-        List<SpecificResumeResponseDto> specific
+        List<ResumeResponse> resumeList
 ) {
-    public static ResumeListResponse of(List<CommonResumeResponse> common, List<SpecificResumeResponseDto> specific) {
-        return new ResumeListResponse(common, specific);
+    public static ResumeListResponse of(List<ResumeResponse> resumeList) {
+        return new ResumeListResponse(resumeList);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeResponse.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import java.util.List;
+
+public record ResumeResponse(
+        Long resumeId,
+        List<CommonResumeResponse> common,
+        List<SpecificResumeResponseDto> specific
+) {
+    public static ResumeResponse of(Long resumeId,
+                                    List<CommonResumeResponse> common,
+                                    List<SpecificResumeResponseDto> specific) {
+        return new ResumeResponse(resumeId, common, specific);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/SpecificResumeResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/SpecificResumeResponseDto.java
@@ -1,0 +1,17 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+
+import java.util.List;
+
+public record SpecificResumeResponseDto(
+        Long resumeId,
+        List<DetailResumeQuestionResponse> specificQuestions,
+        List<LanguageLevelResponseDto> languageLevels
+) {
+    public static SpecificResumeResponseDto of(Long resumeId,
+                                               List<DetailResumeQuestionResponse> specificQuestions,
+                                               List<LanguageLevelResponseDto> languageLevels) {
+        return new SpecificResumeResponseDto(resumeId, specificQuestions, languageLevels);
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -13,6 +13,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,17 +73,22 @@ public class Resume extends BaseEntity {
     @JoinColumn(name = "memberId", nullable = false)
     private Member member;
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @Fetch(FetchMode.JOIN)
     private List<ResumeTimeSlot> resumeTimeSlots = new ArrayList<>();
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<LanguageLevel> languageLevels = new ArrayList<>();
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<ResumeQuestion> resumeQuestions = new ArrayList<>();
 
-    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 50)
     private List<ResumeEvaluation> resumeEvaluations = new ArrayList<>();
+
 
     @Builder
     public Resume(String school, String major, String minor, String resumeGeneration, String blogUrl, String githubUrl,
@@ -131,9 +139,9 @@ public class Resume extends BaseEntity {
         this.state = ResumeState.SUBMITTED;
     }
 
-    public boolean isSubmitted() {
-        return this.state == ResumeState.SUBMITTED;
-    }
+//    public boolean isSubmitted() {
+//        return this.state == ResumeState.SUBMITTED;
+//    }
 
     public void updateFinalDocumentEvaluationStatus(EvaluationStatus finalDocumentEvaluationStatus) {
         this.finalDocumentEvaluationStatus = finalDocumentEvaluationStatus;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/entity/Resume.java
@@ -74,7 +74,7 @@ public class Resume extends BaseEntity {
     private Member member;
 
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-    @Fetch(FetchMode.JOIN)
+    @BatchSize(size = 50)
     private List<ResumeTimeSlot> resumeTimeSlots = new ArrayList<>();
 
     @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -138,10 +138,6 @@ public class Resume extends BaseEntity {
         }
         this.state = ResumeState.SUBMITTED;
     }
-
-//    public boolean isSubmitted() {
-//        return this.state == ResumeState.SUBMITTED;
-//    }
 
     public void updateFinalDocumentEvaluationStatus(EvaluationStatus finalDocumentEvaluationStatus) {
         this.finalDocumentEvaluationStatus = finalDocumentEvaluationStatus;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -35,8 +35,8 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
 
     @EntityGraph(attributePaths = {
             "resumeQuestions",
-            "interviewTimes",
-            "programingLanguages"
+            "languageLevels",
+            "resumeTimeSlots"
     })
     Optional<Resume> findWithAllRelationsById(Long id);
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -61,12 +61,11 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
             @Param("status") EvaluationStatus status
     );
 
-    @Query("""
-            SELECT DISTINCT r
-            FROM Resume r
-            LEFT JOIN FETCH r.resumeTimeSlots
-            WHERE r.id IN :resumeIds
-            """)
-    List<Resume> findAllWithResumeTimeSlotsByIdIn(@Param("resumeIds") List<Long> resumeIds);
+    @EntityGraph(attributePaths = {
+            "resumeQuestions",
+            "resumeTimeSlots",
+            "programingLanguages"
+    })
+    List<Resume> findAllWithRelationsByIdIn(List<Long> resumeIds);
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -3,16 +3,15 @@ package com.tave.tavewebsite.domain.resume.repository;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.resume.entity.EvaluationStatus;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
-
-import java.util.List;
-import java.util.Optional;
-
 import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCustomRepository {
@@ -52,14 +51,22 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
 
     // FIXME - BETA TEST REPO 기능
     @Query("""
-        SELECT r
-        FROM Resume r
-        JOIN FETCH r.member m
-        LEFT JOIN FETCH r.resumeTimeSlots rts
-        WHERE r.finalDocumentEvaluationStatus = :status
-        """)
+            SELECT r
+            FROM Resume r
+            JOIN FETCH r.member m
+            LEFT JOIN FETCH r.resumeTimeSlots rts
+            WHERE r.finalDocumentEvaluationStatus = :status
+            """)
     List<Resume> findAllWithMemberAndTimeSlotsByStatus(
             @Param("status") EvaluationStatus status
     );
+
+    @Query("""
+            SELECT DISTINCT r
+            FROM Resume r
+            LEFT JOIN FETCH r.resumeTimeSlots
+            WHERE r.id IN :resumeIds
+            """)
+    List<Resume> findAllWithResumeTimeSlotsByIdIn(@Param("resumeIds") List<Long> resumeIds);
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -16,15 +16,14 @@ import com.tave.tavewebsite.domain.resume.repository.ResumeQuestionJdbcRepositor
 import com.tave.tavewebsite.domain.resume.repository.ResumeQuestionRepository;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import com.tave.tavewebsite.global.common.FieldType;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -158,7 +158,7 @@ public class ResumeQuestionService {
 
     @Transactional(readOnly = true)
     public ResumeListResponse getResumeListDetails(List<Long> resumeIds) {
-        List<Resume> resumes = resumeRepository.findAllWithResumeTimeSlotsByIdIn(resumeIds);
+        List<Resume> resumes = resumeRepository.findAllWithRelationsByIdIn(resumeIds);
 
         List<ResumeResponse> resumeResponseList = new ArrayList<>();
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -159,7 +159,7 @@ public class ResumeQuestionService {
 
     @Transactional(readOnly = true)
     public ResumeListResponse getResumeListDetails(List<Long> resumeIds) {
-        List<Resume> resumes = resumeRepository.findAllById(resumeIds);
+        List<Resume> resumes = resumeRepository.findAllWithResumeTimeSlotsByIdIn(resumeIds);
 
         List<CommonResumeResponse> commonList = new ArrayList<>();
         List<SpecificResumeResponseDto> specificList = new ArrayList<>();

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -160,18 +160,13 @@ public class ResumeQuestionService {
     public ResumeListResponse getResumeListDetails(List<Long> resumeIds) {
         List<Resume> resumes = resumeRepository.findAllWithResumeTimeSlotsByIdIn(resumeIds);
 
-        List<CommonResumeResponse> commonList = new ArrayList<>();
-        List<SpecificResumeResponseDto> specificList = new ArrayList<>();
+        List<ResumeResponse> resumeResponseList = new ArrayList<>();
 
         for (Resume resume : resumes) {
             List<DetailResumeQuestionResponse> commonQuestions = getResumeQuestionList(resume, FieldType.COMMON);
             List<DetailResumeQuestionResponse> specificQuestions = getResumeQuestionList(resume, resume.getField());
 
-            List<LanguageLevelResponseDto> languageLevels = resume.getProgramingLanguages().stream()
-                    .map(LanguageLevelResponseDto::fromEntity)
-                    .toList();
-
-            commonList.add(CommonResumeResponse.of(
+            List<CommonResumeResponse> commonList = List.of(CommonResumeResponse.of(
                     resume.getId(),
                     resume.getBlogUrl(),
                     resume.getGithubUrl(),
@@ -179,14 +174,19 @@ public class ResumeQuestionService {
                     commonQuestions
             ));
 
-            specificList.add(SpecificResumeResponseDto.of(
+            List<LanguageLevelResponseDto> languageLevels = resume.getProgramingLanguages().stream()
+                    .map(LanguageLevelResponseDto::fromEntity)
+                    .toList();
+
+            List<SpecificResumeResponseDto> specificList = List.of(SpecificResumeResponseDto.of(
                     resume.getId(),
                     specificQuestions,
                     languageLevels
             ));
+
+            resumeResponseList.add(ResumeResponse.of(resume.getId(), commonList, specificList));
         }
 
-        return ResumeListResponse.of(commonList, specificList);
+        return ResumeListResponse.of(resumeResponseList);
     }
-
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -166,13 +166,7 @@ public class ResumeQuestionService {
             List<DetailResumeQuestionResponse> commonQuestions = getResumeQuestionList(resume, FieldType.COMMON);
             List<DetailResumeQuestionResponse> specificQuestions = getResumeQuestionList(resume, resume.getField());
 
-            List<CommonResumeResponse> commonList = List.of(CommonResumeResponse.of(
-                    resume.getId(),
-                    resume.getBlogUrl(),
-                    resume.getGithubUrl(),
-                    resume.getPortfolioUrl(),
-                    commonQuestions
-            ));
+            List<CommonResumeResponse> commonList = List.of(CommonResumeResponse.of(resume, commonQuestions));
 
             List<LanguageLevelResponseDto> languageLevels = resume.getProgramingLanguages().stream()
                     .map(LanguageLevelResponseDto::fromEntity)


### PR DESCRIPTION
## ➕ 연관된 이슈
> #203 
> Close #203 

## 📑 작업 내용
> - 지원서 리스트 조회 기능을 추가했습니다.
> - 지원서 ID 리스트를 받아 해당 지원서들을 조회하는 서비스 메서드를 구현했습니다.
> - 조회된 지원서 리스트를 분야별 질문, 공통 질문으로 분리하여 DTO로 변환했습니다.
> - 응답 포맷 통일을 위해 `ResumeListResponse` DTO 생성 및 적용했습니다.

> - `ResumeListResponse` 내에 `List<ResumeResponse>` 포함하도록 변경했고 `resumeId`, `common`, `specific` 필드를 추가했습니다.
> - 프론트 요구사항에 맞춘 JSON 형식으로 데이터 반환하도록 수정했습니다.
> - Hibernate 통계 로그 활성화 후 SQL 쿼리 실행 횟수를 확인했습니다. (쿼리 실행 로그 첨부했습니다.)
> - @EntityGraph를 적용하여 N+1 문제를 제거하고, Resume + 연관 엔티티들을 단 1개의 쿼리로 가져오도록 최적화했습니다.

## ✂️ 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c730c30c-0233-4808-925c-d727892c5213)

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
