### PR TITLE
[Feat] Interveiwfinal 생성 test 기능 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -78,7 +78,7 @@ public class InterviewFinalController {
         return new SuccessResponse<>(response,INTERVIEW_FINAL_TIME_TABLE_LIST.getMessage());
     }
 
-    @PostMapping("/v1/manager/skrr")
+    @PostMapping("/v1/manager/test/interview-final")
     public SuccessResponse saveInterviewFinalTest() {
 
         interviewFinalUseCase.getInterviewFinalSaveListTestVersion();

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalDetailDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalForMemberDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.InterviewTimeTableDto;
+import com.tave.tavewebsite.domain.interviewfinal.service.InterviewFinalTestService;
 import com.tave.tavewebsite.domain.interviewfinal.usecase.InterviewFinalUseCase;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.global.security.CurrentMember;
@@ -75,6 +76,14 @@ public class InterviewFinalController {
         InterviewTimeTableDto response = interviewFinalUseCase.getTimeTableList(generation);
 
         return new SuccessResponse<>(response,INTERVIEW_FINAL_TIME_TABLE_LIST.getMessage());
+    }
+
+    @PostMapping("/v1/manager/skrr")
+    public SuccessResponse saveInterviewFinalTest() {
+
+        interviewFinalUseCase.getInterviewFinalSaveListTestVersion();
+
+        return new SuccessResponse<>(BETA_INTERVIEW_FINAL_LIST_CREATED.getMessage());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -7,10 +7,15 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+
     INTERVIEW_FINAL_TIME_TABLE_LIST(200, "면접 시간표를 조회합니다."),
     INTERVIEW_FINAL_MEMBER_INFO(200, "회원의 면접 시간 및 장소 정보를 제공합니다."),
     INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다."),
-    INTERVIEW_FINAL_LIST_GET(200, "최종 면접 페이지네이션 데이터를 반환합니다");
+    INTERVIEW_FINAL_LIST_GET(200, "최종 면접 페이지네이션 데이터를 반환합니다"),
+
+    // 베타 테스트 용 기능
+    BETA_INTERVIEW_FINAL_LIST_CREATED(200, "[BETA] 최종 면접 데이터를 DB에 저장했습니다.");
+
 
     private final int code;
     private final String message;

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewFinalTestService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewFinalTestService.java
@@ -1,0 +1,56 @@
+package com.tave.tavewebsite.domain.interviewfinal.service;
+
+import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
+import com.tave.tavewebsite.domain.resume.entity.EvaluationStatus;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.domain.resume.entity.ResumeTimeSlot;
+import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewFinalTestService {
+
+    private final ResumeRepository resumeRepository;
+    private final InterviewSaveService InterviewSaveService;
+
+    public void saveResumePassListTestVersion() {
+        List<Resume> resumeList = getResumePassList();
+
+        List<InterviewFinalSaveDto> saveList = resumeList.stream()
+                .filter(resume -> !resume.getResumeTimeSlots().isEmpty())
+                .map(this::mapResumeToInterviewFinalSaveDto)
+                .toList();
+
+
+        InterviewSaveService.saveInterviewFinalList(saveList);
+    }
+
+
+    private List<Resume> getResumePassList() {
+        return resumeRepository.findAllWithMemberAndTimeSlotsByStatus(EvaluationStatus.PASS);
+    }
+
+    public InterviewFinalSaveDto mapResumeToInterviewFinalSaveDto(Resume resume) {
+
+        ResumeTimeSlot idxZeroTimeSlot = resume.getResumeTimeSlots().get(0);
+        LocalDateTime interviewDateTime = idxZeroTimeSlot.getInterviewDetailTime();
+
+        return InterviewFinalSaveDto.builder()
+                .username(resume.getMember().getUsername())
+                .email(resume.getMember().getEmail())
+                .generation(resume.getResumeGeneration())
+                .sex(resume.getMember().getSex())
+                .fieldType(resume.getField())
+                .university(resume.getSchool())
+                .interviewDate(interviewDateTime.toLocalDate())
+                .interviewTime(interviewDateTime.toLocalTime())
+                .resumeId(resume.getId())
+                .memberId(resume.getMember().getId())
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -11,6 +11,7 @@ import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.TotalDa
 import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
 import com.tave.tavewebsite.domain.interviewfinal.mapper.InterviewFinalMapper;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
+import com.tave.tavewebsite.domain.interviewfinal.service.InterviewFinalTestService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewSaveService;
 import com.tave.tavewebsite.domain.interviewfinal.utils.InterviewGroupUtil;
@@ -40,6 +41,7 @@ public class InterviewFinalUseCase {
     private final InterviewExcelService interviewExcelService;
     private final InterviewSaveService interviewSaveService;
     private final InterviewGetService interviewGetService;
+    private final InterviewFinalTestService interviewTestService; // todo 베타 테스트 용 로직.
     private final S3DownloadSerivce s3DownloadSerivce;
     private final InterviewPlaceService interviewPlaceService;
     private final InterviewFinalMapper mapper;
@@ -102,6 +104,13 @@ public class InterviewFinalUseCase {
 
         return InterviewTimeTableDto.of(totalDateTimeList, timeTableList);
     }
+
+    // todo 베타 테스트용 기능이므로 추 후 삭제할 것.
+    public void getInterviewFinalSaveListTestVersion() {
+        interviewTestService.saveResumePassListTestVersion();
+    }
+
+
 
     /*
     * refactor

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -49,4 +49,17 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
     List<Tuple> findResumesWithInterviewTimesAndMemberByGenerationAndStatus(
             @Param("generation") String generation,
             @Param("evaluationStatus") EvaluationStatus evaluationStatus);
+
+    // FIXME - BETA TEST REPO 기능
+    @Query("""
+        SELECT r
+        FROM Resume r
+        JOIN FETCH r.member m
+        LEFT JOIN FETCH r.resumeTimeSlots rts
+        WHERE r.finalDocumentEvaluationStatus = :status
+        """)
+    List<Resume> findAllWithMemberAndTimeSlotsByStatus(
+            @Param("status") EvaluationStatus status
+    );
+
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #205
> Close #205

## 📑 작업 내용
> - Interveiwfinal 생성 test 기능 추가

엑셀 과정을 거치지 않고 서류 합격자들의 InterviewFinal을 바로 생성하는 API를 구현했습니다.
베타 테스트에서 사용할 기능이므로 추후 삭제합니다.


## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
