### PR TITLE
fix: 소셜 링크 및 포트폴리오 DB 저장과 Redis 임시저장 동기화 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
@@ -1,8 +1,10 @@
 package com.tave.tavewebsite.domain.resume.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tave.tavewebsite.domain.resume.dto.request.ResumeReqDto;
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.response.SocialLinksResponseDto;
+import com.tave.tavewebsite.domain.resume.dto.wrapper.ResumeTempWrapper;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
 import com.tave.tavewebsite.domain.resume.exception.TempNotFoundException;
@@ -19,21 +21,49 @@ public class SocialLinksService {
     private final ResumeRepository resumeRepository;
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
+    private final ResumeAnswerTempService resumeAnswerTempService;
 
-    public SocialLinksService(ResumeRepository resumeRepository, RedisUtil redisUtil, ObjectMapper objectMapper) {
+    public SocialLinksService(ResumeRepository resumeRepository, RedisUtil redisUtil, ObjectMapper objectMapper, ResumeAnswerTempService resumeAnswerTempService) {
         this.resumeRepository = resumeRepository;
         this.redisUtil = redisUtil;
         this.objectMapper = objectMapper;
+        this.resumeAnswerTempService = resumeAnswerTempService;
     }
 
     // 소셜 링크 등록
-    @Transactional
-    public void createSocialLinks(Long resumeId, SocialLinksRequestDto socialLinksRequestDto) {
+//    @Transactional
+//    public void createSocialLinks(Long resumeId, SocialLinksRequestDto socialLinksRequestDto) {
+//        Resume resume = resumeRepository.findById(resumeId)
+//                .orElseThrow(ResumeNotFoundException::new);
+//
+//        resume.updateSocialLinks(socialLinksRequestDto); // 이미 존재하는 resume 객체에 소셜 링크 정보 추가
+//    }
+
+    // ResumeTempWrapper에 접근해서 page3 갱신하는 로직
+    public void createSocialLinks(Long resumeId, SocialLinksRequestDto dto) {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        resume.updateSocialLinks(socialLinksRequestDto); // 이미 존재하는 resume 객체에 소셜 링크 정보 추가
+        resume.updateSocialLinks(dto);
+
+        // Redis에서 기존 temp wrapper 조회
+        ResumeTempWrapper existing = resumeAnswerTempService.getTempSavedAnswers(resumeId);
+
+        ResumeReqDto oldPage3 = existing.getPage3();
+
+        // 기존 page3의 타임슬롯 유지 + 소셜 링크만 갱신
+        ResumeReqDto updatedPage3 = new ResumeReqDto(
+                oldPage3 != null ? oldPage3.answers() : null,
+                oldPage3 != null ? oldPage3.timeSlots() : null,
+                null,
+                dto.getGithubUrl(),
+                dto.getBlogUrl(),
+                oldPage3 != null ? oldPage3.portfolioUrl() : null // 포폴은 아래에서 따로 처리
+        );
+
+        resumeAnswerTempService.tempSaveAnswers(resumeId, 3, updatedPage3);
     }
+
 
     // 소셜 링크 조회
     public SocialLinksResponseDto getSocialLinks(Long resumeId) {
@@ -46,20 +76,24 @@ public class SocialLinksService {
             if (redisJson != null) {
                 try {
                     SocialLinksRequestDto dto = objectMapper.readValue(redisJson, SocialLinksRequestDto.class);
-                    return new SocialLinksResponseDto(
-                            dto.getBlogUrl(), dto.getGithubUrl(), portfolioUrl
-                    );
+                    return new SocialLinksResponseDto(dto.getBlogUrl(), dto.getGithubUrl(), portfolioUrl);
                 } catch (Exception parseError) {
-                    // Redis 파싱 실패 → DB fallback, parseError;
+                    // JSON 파싱 실패 → fallback
                 }
             }
         } catch (Exception redisError) {
-            // Redis 접근 실패 → DB fallback, redisError;
+            // Redis 접근 실패 → fallback
         }
 
         // DB fallback
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
+
+        // Redis에 다시 저장
+        SocialLinksRequestDto fallbackDto = new SocialLinksRequestDto(
+                resume.getBlogUrl(), resume.getGithubUrl()
+        );
+        saveSocialLinksToRedis(resumeId, fallbackDto);
 
         return new SocialLinksResponseDto(
                 resume.getBlogUrl(),
@@ -67,6 +101,7 @@ public class SocialLinksService {
                 portfolioUrl
         );
     }
+
 
 //    public SocialLinksResponseDto getSocialLinks(Long resumeId) {
 //        Resume resume = resumeRepository.findById(resumeId)
@@ -77,20 +112,42 @@ public class SocialLinksService {
 
     // 소셜 링크 업데이트
     @Transactional
-    public void updateSocialLinks(Long resumeId, SocialLinksRequestDto socialLinksRequestDto) {
+    public void updateSocialLinks(Long resumeId, SocialLinksRequestDto dto) {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        resume.updateSocialLinks(socialLinksRequestDto);
+        resume.updateSocialLinks(dto);
+
+        ResumeReqDto page3 = new ResumeReqDto(null, null, null,
+                dto.getGithubUrl(), dto.getBlogUrl(), null);
+
+        resumeAnswerTempService.tempSaveAnswers(resumeId, 3, page3); // Redis에도 저장
     }
 
-    @Transactional
+
     public void updatePortfolio(Long resumeId, String portfolioUrl) {
         Resume resume = resumeRepository.findById(resumeId)
                 .orElseThrow(ResumeNotFoundException::new);
 
-        resume.updatePortfolio(portfolioUrl); // Resume 엔티티에 메서드 추가 필요
+        resume.updatePortfolio(portfolioUrl);
+        resumeRepository.save(resume);
+
+        // Redis에서 기존 temp wrapper 조회
+        ResumeTempWrapper existing = resumeAnswerTempService.getTempSavedAnswers(resumeId);
+        ResumeReqDto oldPage3 = existing.getPage3();
+
+        ResumeReqDto updatedPage3 = new ResumeReqDto(
+                oldPage3 != null ? oldPage3.answers() : null,
+                oldPage3 != null ? oldPage3.timeSlots() : null,
+                null,
+                oldPage3 != null ? oldPage3.githubUrl() : null,
+                oldPage3 != null ? oldPage3.blogUrl() : null,
+                portfolioUrl // 새로운 포폴 주소
+        );
+
+        resumeAnswerTempService.tempSaveAnswers(resumeId, 3, updatedPage3);
     }
+
 
     // Redis에 임시 저장
     public void saveSocialLinksToRedis(Long resumeId, SocialLinksRequestDto dto) {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
@@ -154,7 +154,7 @@ public class SocialLinksService {
         try {
             String key = "resume:" + resumeId + ":socialLinks";
             String value = objectMapper.writeValueAsString(dto);
-            redisUtil.set(key, value, 86400); // TTL 1일
+            redisUtil.set(key, value, 2592000);
         } catch (Exception e) {
             throw new TempSaveFailedException();
         }
@@ -163,7 +163,7 @@ public class SocialLinksService {
     public void savePortfolioToRedis(Long resumeId, String portfolioUrl) {
         try {
             String key = "resume:" + resumeId + ":portfolioUrl";
-            redisUtil.set(key, portfolioUrl, 86400); // TTL 1일
+            redisUtil.set(key, portfolioUrl, 2592000);
         } catch (Exception e) {
             throw new TempSaveFailedException();
         }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #210
> Close #210

## 📑 작업 내용
> - 소셜 링크 및 포트폴리오 주소를 DB에 저장하는 동시에 Redis 임시저장 데이터(`ResumeTempWrapper`)의 page3에 동기화하여 임시저장 조회 시 최신 데이터가 반영되도록 구현했습니다.
> - 소셜 링크 등록, 수정, 포트폴리오 업로드 시 각각 DB 저장 및 Redis 임시저장 데이터 갱신 로직을 추가했습니다.
> - 기존 Redis 내 임시저장 데이터에서 page3 정보 조회 후, 기존 타임슬롯과 답변은 유지하고 소셜 링크 및 포트폴리오 주소만 업데이트하는 방식으로 구현했습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
