### PR TITLE
[Feat] 서류 제출기한 검증 API

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/controller/ApplyInitialSetupController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/controller/ApplyInitialSetupController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.tave.tavewebsite.domain.apply.initial.setup.controller.ApplyInitialSetupSuccessMessage.CHECK_APPLY_RECRUIT_END_DATE;
+
 @RestController
 @RequiredArgsConstructor
 public class ApplyInitialSetupController {
@@ -41,5 +43,12 @@ public class ApplyInitialSetupController {
     public SuccessResponse deleteApplyInitialSetup() {
         applyInitialSetupService.deleteInitialSetup();
         return SuccessResponse.ok(ApplyInitialSetupSuccessMessage.APPLY_INITIAL_SETUP_DELETE_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/v1/member/apply-recruit/expiration")
+    public SuccessResponse<Boolean> checkApplyEndDateExpiration() {
+        boolean result = applyInitialSetupService.checkRecruitExpiration();
+
+        return new SuccessResponse<>(result, CHECK_APPLY_RECRUIT_END_DATE.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/controller/ApplyInitialSetupSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/controller/ApplyInitialSetupSuccessMessage.java
@@ -9,7 +9,8 @@ public enum ApplyInitialSetupSuccessMessage {
     APPLY_INITIAL_SETUP_READ_SUCCESS("지원 초기 설정 조회에 성공했습니다."),
     APPLY_INITIAL_SETUP_SAVE_SUCCESS("지원 초기 설정 저장에 성공했습니다."),
     APPLY_INITIAL_SETUP_UPDATE_SUCCESS("지원 초기 설정 업데이트에 성공했습니다."),
-    APPLY_INITIAL_SETUP_DELETE_SUCCESS("지원 초기 설정 삭제에 성공했습니다.");
+    APPLY_INITIAL_SETUP_DELETE_SUCCESS("지원 초기 설정 삭제에 성공했습니다."),
+    CHECK_APPLY_RECRUIT_END_DATE("지원 기간 여부를 확인합니다.");
 
     private final String message;
 

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/entity/ApplyInitialSetup.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/entity/ApplyInitialSetup.java
@@ -101,4 +101,9 @@ public class ApplyInitialSetup extends BaseEntity {
         this.lastAnnouncementFlag = LastAnnouncementFlag;
     }
 
+    public boolean isOverDocumentEndDate() {
+
+        return (LocalDateTime.now().isBefore(this.documentRecruitEndDate));
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
@@ -8,6 +8,8 @@ import com.tave.tavewebsite.domain.apply.initial.setup.repository.ApplyInitialSe
 import com.tave.tavewebsite.domain.apply.initial.setup.util.ApplyInitialSetUpMapper;
 import com.tave.tavewebsite.domain.resume.batch.exception.RecruitmentBatchJobException.DocumentResultBatchJobFailException;
 import jakarta.servlet.http.HttpServletRequest;
+
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +54,13 @@ public class ApplyInitialSetupService {
         }
 
         applyInitialSetupRepository.deleteById(1L);
+    }
+
+    public boolean checkRecruitExpiration() {
+        ApplyInitialSetup applyInitialSetup = applyInitialSetupRepository.findById(1L)
+                .orElseThrow(ApplyInitialSetupNotFoundException::new);
+
+        return applyInitialSetup.isOverDocumentEndDate();
     }
 
     public void changeDocumentAnnouncementFlag(Boolean flag, HttpServletRequest request) {


### PR DESCRIPTION
## ➕ 연관된 이슈
> #214 
> Close #214

## 📑 작업 내용
> - 현재 서류 지원이 마감되었는 지 여부를 확인하는 API를 구현했습니다.

아직 서류 지원이 가능한 경우 true, 서류 지원이 마감된 경우 false를 반환합니다.

![image](https://github.com/user-attachments/assets/f7e8af6c-73fe-4d6a-91fb-a5044454e344)


## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
