### PR TITLE
[fix] FinalPass 날짜 포맷 형식 변경

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/request/FinalPassRequestDto.java
@@ -1,11 +1,12 @@
 package com.tave.tavewebsite.domain.finalpass.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -23,7 +24,8 @@ public class FinalPassRequestDto {
 
     @NotNull(message = "회비 납부 마감기한 필수로 입력해주세요.")
     @FutureOrPresent(message = "회비 납부 마감기한은 오늘 또는 미래여야 합니다.")
-    private LocalDate feeDeadline;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime feeDeadline;
 
     @NotBlank(message = "은행명 필수로 입력해주세요.")
     @Size(max = 10, message = "은행명은 10자 이하로 입력해주세요.")
@@ -43,7 +45,8 @@ public class FinalPassRequestDto {
 
     @NotNull(message = "아지트 초대 설문 조사 마감기한 필수로 입력해주세요.")
     @FutureOrPresent(message = "설문 마감기한은 오늘 또는 미래여야 합니다.")
-    private LocalDate surveyDeadline;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime surveyDeadline;
 
     @NotBlank(message = "OT 공지방 링크 필수로 입력해주세요.")
     @Size(max = 200, message = "링크는 200자 이하로 입력해주세요.")
@@ -55,5 +58,6 @@ public class FinalPassRequestDto {
 
     @NotNull(message = "OT 마감기한 필수로 입력해주세요. ")
     @FutureOrPresent(message = "OT 마감기한은 오늘 또는 미래여야 합니다.")
-    private LocalDate otDeadline;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime otDeadline;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/response/FinalPassResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/dto/response/FinalPassResponseDto.java
@@ -3,7 +3,7 @@ package com.tave.tavewebsite.domain.finalpass.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -13,13 +13,13 @@ public class FinalPassResponseDto {
     private Integer totalFee;
     private Integer clubFee;
     private Integer mtFee;
-    private LocalDate feeDeadline;
+    private LocalDateTime feeDeadline;
     private String bankName;
     private String accountNumber;
     private String accountHolder;
     private String surveyLink;
-    private LocalDate surveyDeadline;
+    private LocalDateTime surveyDeadline;
     private String otLink;
     private String otPassword;
-    private LocalDate otDeadline;
+    private LocalDateTime otDeadline;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/entity/FinalPass.java
@@ -2,9 +2,12 @@ package com.tave.tavewebsite.domain.finalpass.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -40,7 +43,7 @@ public class FinalPass {
 
     @NotNull
     @Column(nullable = false)
-    private LocalDate feeDeadline;
+    private LocalDateTime feeDeadline;
 
     // 아지트 초대 설문 조사
     @NotNull
@@ -49,7 +52,7 @@ public class FinalPass {
 
     @NotNull
     @Column(nullable = false)
-    private LocalDate surveyDeadline;
+    private LocalDateTime surveyDeadline;
 
     // OT 공지방
     @NotNull
@@ -62,5 +65,5 @@ public class FinalPass {
 
     @NotNull
     @Column(nullable = false)
-    private LocalDate otDeadline;
+    private LocalDateTime otDeadline;
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #219
> Close #219

## 📑 작업 내용
> - 최종합격 설정에서 날짜 형식을 LocalDateTime으로 수정해 `yyyy.MM.dd HH:mm` 패턴을 사용하도록 했습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
