### PR TITLE
[Feat] 면접관 시간표 파일 업로드 및 다운로드 API

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -2,15 +2,16 @@ package com.tave.tavewebsite.domain.interviewfinal.controller;
 
 import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.usecase.InterviewExcelUseCase;
+import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED;
 
 @RestController
 @RequestMapping("/v1/manager")
@@ -34,6 +35,17 @@ public class InterviewExcelController {
                 .headers(dto.headers())
                 .contentLength(dto.contentLength())
                 .body(dto.inputStreamResource());
+    }
+
+    // 면접관 전용 시간표 파일 업로드
+    @PostMapping("/interview/time-table")
+    public SuccessResponse saveInterviewTimeTableForManager(
+            @RequestPart(name="file") MultipartFile file
+    ) {
+
+        useCase.saveInterviewTimeTableForManagerXLSX(file);
+
+        return SuccessResponse.ok(INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED.getMessage());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -48,4 +48,15 @@ public class InterviewExcelController {
         return SuccessResponse.ok(INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED.getMessage());
     }
 
+    // 면접관 전용 시간표 파일 다운로드
+    @GetMapping("/interview/time-table")
+    public ResponseEntity<InputStreamResource> downloadInterviewTimeTableForManager() throws IOException {
+        S3ExcelFileInputStreamDto dto = useCase.getInterviewTimeTableForManagerXLSX();
+
+        return ResponseEntity.ok()
+                .headers(dto.headers())
+                .contentLength(dto.contentLength())
+                .body(dto.inputStreamResource());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -38,7 +38,7 @@ public class InterviewExcelController {
     }
 
     // 면접관 전용 시간표 파일 업로드
-    @PostMapping("/interview/time-table")
+    @PostMapping("/excel/interview/time-table")
     public SuccessResponse saveInterviewTimeTableForManager(
             @RequestPart(name="file") MultipartFile file
     ) {
@@ -49,7 +49,7 @@ public class InterviewExcelController {
     }
 
     // 면접관 전용 시간표 파일 다운로드
-    @GetMapping("/interview/time-table")
+    @GetMapping("/excel/interview/time-table")
     public ResponseEntity<InputStreamResource> downloadInterviewTimeTableForManager() throws IOException {
         S3ExcelFileInputStreamDto dto = useCase.getInterviewTimeTableForManagerXLSX();
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-
+    INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED(200, "면접에 참여하는 운영진이 볼 [면접 시간표]를 업로드했습니다"),
     INTERVIEW_FINAL_TIME_TABLE_LIST(200, "면접 시간표를 조회합니다."),
     INTERVIEW_FINAL_MEMBER_INFO(200, "회원의 면접 시간 및 장소 정보를 제공합니다."),
     INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/EmptyFileException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/EmptyFileException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.interviewfinal.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.exception.ErrorMessage.EMPTY_FILE_EXCEPTION;
+
+public class EmptyFileException extends BaseErrorException {
+    public EmptyFileException() {
+        super(EMPTY_FILE_EXCEPTION.getCode(), EMPTY_FILE_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/ErrorMessage.java
@@ -9,6 +9,8 @@ public enum ErrorMessage {
 
     // InterviewFinal 오류
     NOT_FOUND_INTERVIEW_FINAL_BY_MEMBER(400,"해당 멤버의 면접 정보를 찾을 수 없습니다. "),
+    EMPTY_FILE_EXCEPTION(400, "요청에 파일이 존재하지 않습니다."),
+    IS_NOT_XLSX_FILE_EXCEPTION(400, "해당 파일의 확장자가 XLSX가 아닙니다."),
 
     // 엑셀 오류
     EXCEL_BAD_REQUEST_EXCEPTION(400, "엑셀 오류"),

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/IsNotXlsxFileException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/exception/IsNotXlsxFileException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.interviewfinal.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.interviewfinal.exception.ErrorMessage.IS_NOT_XLSX_FILE_EXCEPTION;
+
+public class IsNotXlsxFileException extends BaseErrorException {
+    public IsNotXlsxFileException() {
+        super(IS_NOT_XLSX_FILE_EXCEPTION.getCode(), IS_NOT_XLSX_FILE_EXCEPTION.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -48,6 +49,10 @@ public class InterviewExcelUseCase {
 
     public S3ExcelFileInputStreamDto getPossibleInterviewTimeCSV() throws IOException {
         return s3DownloadSerivce.downloadPossibleTimeTableXlsx();
+    }
+
+    public void saveInterviewTimeTableForManagerXLSX(MultipartFile file) {
+        s3Service.uploadTimeTableForMangerXLSXToS3(file);
     }
 
     /*

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
@@ -55,6 +55,11 @@ public class InterviewExcelUseCase {
         s3Service.uploadTimeTableForMangerXLSXToS3(file);
     }
 
+    public S3ExcelFileInputStreamDto getInterviewTimeTableForManagerXLSX() throws IOException {
+        return s3DownloadSerivce.downloadInterviewTimeTableForManagerXLSX();
+    }
+
+
     /*
     * refactor
     * */

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -19,19 +19,23 @@ public class S3DownloadSerivce {
     private final String bucketName;
     private final String finalInterviewBasicFormUrl;
     private final String interviewPossibleTimeTable;
+    private final String interviewTimeTableForManager;
     private static final String FINAL_INTERVIEW_FORM_NAME = "최종 면접 시간표 설정 양식.xlsx";
     private static final String POSSIBLE_TIME_TABLE_FORM_NAME = "면접자 면접가능시간.xlsx";
+    private static final String INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME = "면접관 전용 면접시간표.xlsx";
     private static final String HEADER_ATTACHMENT = "attachment";
 
     public S3DownloadSerivce(AmazonS3 s3Client,@Value("${bucket_name}") String bucketName,
              @Value("${final_interview_form}") String finalInterviewBasicFormUrl,
-             @Value("${interview_possible_time_table}") String interviewPossibleTimeTable
+             @Value("${interview_possible_time_table}") String interviewPossibleTimeTable,
+             @Value("${interview_time_table_for_manager}") String interviewTimeTableForManager
 
     ) {
         this.s3Client = s3Client;
         this.bucketName = bucketName;
         this.finalInterviewBasicFormUrl = finalInterviewBasicFormUrl;
         this.interviewPossibleTimeTable = interviewPossibleTimeTable;
+        this.interviewTimeTableForManager = interviewTimeTableForManager;
     }
 
     public S3ExcelFileInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
@@ -46,6 +50,15 @@ public class S3DownloadSerivce {
     public S3ExcelFileInputStreamDto downloadPossibleTimeTableXlsx() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewPossibleTimeTable);
         HttpHeaders headers = createHttpHeaders(POSSIBLE_TIME_TABLE_FORM_NAME);
+
+        return S3ExcelFileInputStreamDto.from(
+                s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
+        );
+    }
+
+    public S3ExcelFileInputStreamDto downloadInterviewTimeTableForManagerXLSX() throws IOException {
+        S3Object s3Object = s3Client.getObject(bucketName, interviewTimeTableForManager);
+        HttpHeaders headers = createHttpHeaders(INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME);
 
         return S3ExcelFileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
@@ -6,10 +6,12 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.sksamuel.scrimage.ImmutableImage;
 import com.sksamuel.scrimage.webp.WebpWriter;
+import com.tave.tavewebsite.domain.interviewfinal.exception.IsNotXlsxFileException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3ConvertFailException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3NotExistNameException;
 import com.tave.tavewebsite.global.s3.exception.S3ErrorException.S3UploadFailException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.EmptyFileException;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -27,13 +29,20 @@ public class S3Service {
     private final AmazonS3 s3Client;
     private final String bucketName;
     private final String possibleTimeTableXLSX;
+    private final String interviewTimeTableForManagerXLSX;
+
+
+    private String key1;
 
     private static final String XLSX_APPLICATION_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-    public S3Service(AmazonS3 s3Client, @Value("${bucket_name}") String bucketName, @Value("${interview_possible_time_table}") String interviewPossibleTimeTable ) {
+    public S3Service(AmazonS3 s3Client, @Value("${bucket_name}") String bucketName,
+                     @Value("${interview_possible_time_table}") String interviewPossibleTimeTable,
+                     @Value("${interview_time_table_for_manager}") String interviewTimeTableForManager ) {
         this.s3Client = s3Client;
         this.bucketName = bucketName;
         this.possibleTimeTableXLSX = interviewPossibleTimeTable;
+        this.interviewTimeTableForManagerXLSX= interviewTimeTableForManager;
     }
 
     public URL uploadImages(MultipartFile file) {
@@ -104,6 +113,20 @@ public class S3Service {
             throw new S3UploadFailException();
         }
     }
+
+    public void uploadTimeTableForMangerXLSXToS3(MultipartFile file) {
+        try {
+            checkEmptyFile(file);
+            checkIsXLSXFile(file);
+
+            storeXLSXFile(file, interviewTimeTableForManagerXLSX);
+
+        } catch (IOException e) {
+            throw new S3UploadFailException();
+        }
+    }
+
+
 
     public URL getImageUrl(String key) {
         try {
@@ -180,6 +203,27 @@ public class S3Service {
             return key.substring(dotIndex);
         }
         return ""; // 확장자가 없는 경우 빈 문자열 반환
+    }
+
+    private void storeXLSXFile(MultipartFile file, String key) throws IOException {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        // S3에 업로드 (동일 키가 있으면 덮어쓰기)
+        s3Client.putObject(bucketName, key, file.getInputStream(), metadata);
+    }
+
+    private void checkEmptyFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new EmptyFileException();
+        }
+    }
+
+    private void checkIsXLSXFile(MultipartFile file) {
+        if (!XLSX_APPLICATION_TYPE.equals(file.getContentType())) {
+            throw new IsNotXlsxFileException();
+        }
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,7 @@ cloud:
 
 final_interview_form: ${FINAL_INTERVIEW_FORM}
 interview_possible_time_table: ${INTERVIEW_POSSIBLE_TIME_TABLE_XLSX}
+interview_time_table_for_manager: ${INTERVIEW_TIME_TABLE_FOR_MANAGER}
 
 logging:
   level:

--- a/src/test/java/com/tave/tavewebsite/global/s3/service/S3ServiceTest.java
+++ b/src/test/java/com/tave/tavewebsite/global/s3/service/S3ServiceTest.java
@@ -20,7 +20,7 @@ class S3ServiceTest {
     @BeforeEach
     void setUp() {
         AmazonS3 s3Client = mock(AmazonS3.class);
-        s3Service = new S3Service(s3Client, "hihi", "dummy"); // 생성자 주입 방식
+        s3Service = new S3Service(s3Client, "hihi", "dummy", ""); // 생성자 주입 방식
     }
 
     @DisplayName("MultipartFile을 .webp으로 업로드합니다.")


### PR DESCRIPTION
## ➕ 연관된 이슈
> #218 
> Close #218 

## 📑 작업 내용
> - `면접관 전용 면접 시간표` 엑셀 파일을 S3에 업로드 및 다운로드하는 API를 구현했습니다.

S3에 올라가는 면접 파일과 관련된 경로는 환경변수로 주입 받아 사용하도록했습니다.
```java
private static final String INTERVIEW_FORM~ = "example.xls":
```
위와 같이 상수로 선언하여 사용해도 되지만,   
면접 관련 파일에는 지원자들의 개인정보가 포함되어 있기 때문에 보안상의 이유로 환경변수로 처리했습니다.

### 도식화

![면접관 전용 시간표 파일 API 구현](https://github.com/user-attachments/assets/f6dea746-1508-400d-91f9-2f1a58120ca1)

S3Service에서 업로드 책임을 가지고 S3DownloadService에서 다운로드의 책임을 가지도록 설계했습니다.
추후 S3Service를 S3UploadService로 리팩토링 한다면 두 서비스간 책임이 명확하게 클래스명에 드러날 거 같아 좋을 거 같습니다.

### 유효성 검증

file이 빈 경우와 file이 xlsx이 아닌 경우에 대비해서 유효성 검증 메서드를 추가해 적용했습니다.

```java
    private void checkEmptyFile(MultipartFile file) {
        if (file.isEmpty()) {
            throw new EmptyFileException();
        }
    }

    private void checkIsXLSXFile(MultipartFile file) {
        if (!XLSX_APPLICATION_TYPE.equals(file.getContentType())) {
            throw new IsNotXlsxFileException();
        }
    }
```


## ✂️ 스크린샷 (선택)
>

### 업로드 테스트

![image](https://github.com/user-attachments/assets/9454eef2-ebfa-4e71-8c27-ed520aba11c0)

### 다운로드 테스트

로컬 환경에서 다운로드에 용이하도록 인가 경로를 잠시 normal로 해두었습니다.
PR에는 manager로 수정해 반영했습니다.

![image](https://github.com/user-attachments/assets/7ed2f5d8-7ece-4245-a1d0-091937311aae)

### 파일의 확장자가 XLSX가 아닌 경우

![image](https://github.com/user-attachments/assets/2362ca78-2154-4d97-b92c-4150dee67d67)


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
