### PR TITLE
Feat 면접 평가 엑셀 API 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.*;
 
 @RestController
-@RequestMapping("/v1/normal")
+@RequestMapping("/v1/manager")
 @RequiredArgsConstructor
 public class InterviewExcelController {
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED;
+import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.*;
 
 @RestController
 @RequestMapping("/v1/normal")
@@ -83,10 +83,12 @@ public class InterviewExcelController {
 
     // 면접 평가 양식에 면접자 데이터 삽입 후 S3에 저장
     @PostMapping("/excel/interview/evaluation")
-    public void saveInterviewEvaluation(
+    public SuccessResponse saveInterviewEvaluation(
             @RequestPart(name="file") MultipartFile file
     ){
         useCase.insertInterviewerAndStoreToS3(file);
+
+        return SuccessResponse.ok(INTERVIEW_EVALUATION_XLSX_SAVED.getMessage());
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -70,4 +70,15 @@ public class InterviewExcelController {
                 .body(dto.inputStreamResource());
     }
 
+    // 면접 평가 시트 다운로드
+    @GetMapping("/excel/interview/evaluation")
+    public ResponseEntity<InputStreamResource> downloadInterviewEvaluation() throws IOException {
+        S3ExcelFileInputStreamDto dto = useCase.getInterviewEvaluationXLSX();
+
+        return ResponseEntity.ok()
+                .headers(dto.headers())
+                .contentLength(dto.contentLength())
+                .body(dto.inputStreamResource());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import static com.tave.tavewebsite.domain.interviewfinal.controller.SuccessMessage.INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED;
 
 @RestController
-@RequestMapping("/v1/manager")
+@RequestMapping("/v1/normal")
 @RequiredArgsConstructor
 public class InterviewExcelController {
 
@@ -52,6 +52,17 @@ public class InterviewExcelController {
     @GetMapping("/excel/interview/time-table")
     public ResponseEntity<InputStreamResource> downloadInterviewTimeTableForManager() throws IOException {
         S3ExcelFileInputStreamDto dto = useCase.getInterviewTimeTableForManagerXLSX();
+
+        return ResponseEntity.ok()
+                .headers(dto.headers())
+                .contentLength(dto.contentLength())
+                .body(dto.inputStreamResource());
+    }
+
+    // 면접 평가 초기 양식 다운로드
+    @GetMapping("/excel/interview/evaluation-form")
+    public ResponseEntity<InputStreamResource> downloadInterviewEvaluationInitialForm() throws IOException {
+        S3ExcelFileInputStreamDto dto = useCase.getInterviewEvaluationInitialFormXLSX();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -81,4 +81,12 @@ public class InterviewExcelController {
                 .body(dto.inputStreamResource());
     }
 
+    // 면접 평가 양식에 면접자 데이터 삽입 후 S3에 저장
+    @PostMapping("/excel/interview/evaluation")
+    public void saveInterviewEvaluation(
+            @RequestPart(name="file") MultipartFile file
+    ){
+        useCase.insertInterviewerAndStoreToS3(file);
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -58,6 +58,14 @@ public class InterviewFinalController {
         return SuccessResponse.ok(INTERVIEW_FINAL_CREATED.getMessage());
     }
 
+    @DeleteMapping("/v1/manager/interview-final")
+    public SuccessResponse interviewFinalDelete() {
+
+        interviewFinalUseCase.deleteAll();
+
+        return SuccessResponse.ok(INTERVIEW_FINAL_DELETE_ALL.getMessage());
+    }
+
     @GetMapping("/v1/manager/interview-final")
     public SuccessResponse interviewFinalPageNation(
         @RequestParam int pageNum,

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum SuccessMessage {
 
     INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED(200, "면접에 참여하는 운영진이 볼 [면접 시간표]를 업로드했습니다"),
+    INTERVIEW_EVALUATION_XLSX_SAVED(200, "면접 평가 시트에 면접자 정보 추가, S3에 업로드했습니다."),
     INTERVIEW_FINAL_DELETE_ALL(200, "최종 면접 데이터를 모두 삭제합니다."),
     INTERVIEW_FINAL_TIME_TABLE_LIST(200, "면접 시간표를 조회합니다."),
     INTERVIEW_FINAL_MEMBER_INFO(200, "회원의 면접 시간 및 장소 정보를 제공합니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/SuccessMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum SuccessMessage {
 
     INTERVIEW_TIME_TABLE_FOR_MANAGER_SAVED(200, "면접에 참여하는 운영진이 볼 [면접 시간표]를 업로드했습니다"),
+    INTERVIEW_FINAL_DELETE_ALL(200, "최종 면접 데이터를 모두 삭제합니다."),
     INTERVIEW_FINAL_TIME_TABLE_LIST(200, "면접 시간표를 조회합니다."),
     INTERVIEW_FINAL_MEMBER_INFO(200, "회원의 면접 시간 및 장소 정보를 제공합니다."),
     INTERVIEW_FINAL_CREATED(200, "최종면접 데이터를 엑셀로부터 추출해 성공적으로 DB에 저장했습니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewDeleteService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/service/InterviewDeleteService.java
@@ -1,0 +1,17 @@
+package com.tave.tavewebsite.domain.interviewfinal.service;
+
+import com.tave.tavewebsite.domain.interviewfinal.repository.InterviewFinalRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewDeleteService {
+
+    private final InterviewFinalRepository interviewFinalRepository;
+
+    public void deleteAll() {
+        interviewFinalRepository.deleteAll();
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
@@ -63,6 +63,11 @@ public class InterviewExcelUseCase {
         return s3DownloadSerivce.downloadInterviewEvaluationInitialFormXLSX();
     }
 
+    public S3ExcelFileInputStreamDto getInterviewEvaluationXLSX() throws IOException {
+        return s3DownloadSerivce.downloadInterviewEvaluationXLSX();
+    }
+
+
     /*
     * refactor
     * */

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
@@ -59,6 +59,9 @@ public class InterviewExcelUseCase {
         return s3DownloadSerivce.downloadInterviewTimeTableForManagerXLSX();
     }
 
+    public S3ExcelFileInputStreamDto getInterviewEvaluationInitialFormXLSX() throws IOException {
+        return s3DownloadSerivce.downloadInterviewEvaluationInitialFormXLSX();
+    }
 
     /*
     * refactor

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -10,10 +10,7 @@ import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.Intervi
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.TotalDateTimeDto;
 import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
 import com.tave.tavewebsite.domain.interviewfinal.mapper.InterviewFinalMapper;
-import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
-import com.tave.tavewebsite.domain.interviewfinal.service.InterviewFinalTestService;
-import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
-import com.tave.tavewebsite.domain.interviewfinal.service.InterviewSaveService;
+import com.tave.tavewebsite.domain.interviewfinal.service.*;
 import com.tave.tavewebsite.domain.interviewfinal.utils.InterviewGroupUtil;
 import com.tave.tavewebsite.domain.interviewplace.dto.response.InterviewPlaceDetailDto;
 import com.tave.tavewebsite.domain.interviewplace.service.InterviewPlaceService;
@@ -41,6 +38,7 @@ public class InterviewFinalUseCase {
     private final InterviewExcelService interviewExcelService;
     private final InterviewSaveService interviewSaveService;
     private final InterviewGetService interviewGetService;
+    private final InterviewDeleteService interviewDeleteService;
     private final InterviewFinalTestService interviewTestService; // todo 베타 테스트 용 로직.
     private final S3DownloadSerivce s3DownloadSerivce;
     private final InterviewPlaceService interviewPlaceService;
@@ -50,6 +48,10 @@ public class InterviewFinalUseCase {
 
     public S3ExcelFileInputStreamDto downloadInterviewFinal() throws IOException {
         return s3DownloadSerivce.downloadInterviewFinalSetUpForm();
+    }
+
+    public void deleteAll() {
+        interviewDeleteService.deleteAll();
     }
 
     public void insertInterviewEntityFromExcel(MultipartFile file) {

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -20,15 +20,21 @@ public class S3DownloadSerivce {
     private final String finalInterviewBasicFormUrl;
     private final String interviewPossibleTimeTable;
     private final String interviewTimeTableForManager;
+    private final String interviewEvaluationInitialForm;
+    private final String interviewEvaluationXLSX;
     private static final String FINAL_INTERVIEW_FORM_NAME = "최종 면접 시간표 설정 양식.xlsx";
     private static final String POSSIBLE_TIME_TABLE_FORM_NAME = "면접자 면접가능시간.xlsx";
     private static final String INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME = "면접관 전용 면접시간표.xlsx";
+    private static final String INTERVIEW_EVALUATION_INITIAL_FORM_NAME = "면접 평가 초기 양식.xlsx";
+    private static final String INTERVIEW_EVALUATION_XLSX_NAME = "면접 평가 시트.xlsx";
     private static final String HEADER_ATTACHMENT = "attachment";
 
     public S3DownloadSerivce(AmazonS3 s3Client,@Value("${bucket_name}") String bucketName,
              @Value("${final_interview_form}") String finalInterviewBasicFormUrl,
              @Value("${interview_possible_time_table}") String interviewPossibleTimeTable,
-             @Value("${interview_time_table_for_manager}") String interviewTimeTableForManager
+             @Value("${interview_time_table_for_manager}") String interviewTimeTableForManager,
+             @Value("${interview_evaluation_initial_form}") String interviewEvaluationInitialForm,
+             @Value("${interview_evaluation_xlsx}") String interviewEvaluationXLSX
 
     ) {
         this.s3Client = s3Client;
@@ -36,6 +42,8 @@ public class S3DownloadSerivce {
         this.finalInterviewBasicFormUrl = finalInterviewBasicFormUrl;
         this.interviewPossibleTimeTable = interviewPossibleTimeTable;
         this.interviewTimeTableForManager = interviewTimeTableForManager;
+        this.interviewEvaluationInitialForm= interviewEvaluationInitialForm;
+        this.interviewEvaluationXLSX = interviewEvaluationXLSX;
     }
 
     public S3ExcelFileInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
@@ -59,6 +67,16 @@ public class S3DownloadSerivce {
     public S3ExcelFileInputStreamDto downloadInterviewTimeTableForManagerXLSX() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewTimeTableForManager);
         HttpHeaders headers = createHttpHeaders(INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME);
+
+        return S3ExcelFileInputStreamDto.from(
+                s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
+        );
+    }
+
+    // 면접 평가 초기 양식 다운로드
+    public S3ExcelFileInputStreamDto downloadInterviewEvaluationInitialFormXLSX() throws IOException {
+        S3Object s3Object = s3Client.getObject(bucketName, interviewEvaluationInitialForm);
+        HttpHeaders headers = createHttpHeaders(INTERVIEW_EVALUATION_INITIAL_FORM_NAME);
 
         return S3ExcelFileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -83,6 +83,16 @@ public class S3DownloadSerivce {
         );
     }
 
+    // 면접 평가 시트 다운로드 (질문 + 면접자 정보)
+    public S3ExcelFileInputStreamDto downloadInterviewEvaluationXLSX() throws IOException {
+        S3Object s3Object = s3Client.getObject(bucketName, interviewEvaluationXLSX);
+        HttpHeaders headers = createHttpHeaders(INTERVIEW_EVALUATION_XLSX_NAME);
+
+        return S3ExcelFileInputStreamDto.from(
+                s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
+        );
+    }
+
     /*
     * refactor
     * */

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -46,6 +46,7 @@ public class S3DownloadSerivce {
         this.interviewEvaluationXLSX = interviewEvaluationXLSX;
     }
 
+    // 최종면접 설정 양식 다운로드
     public S3ExcelFileInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
             S3Object s3Object = s3Client.getObject(bucketName, finalInterviewBasicFormUrl);
             HttpHeaders headers = createHttpHeaders(FINAL_INTERVIEW_FORM_NAME);
@@ -55,6 +56,7 @@ public class S3DownloadSerivce {
             );
     }
 
+    // 서류합격자들 면접 가능 시간 파악 엑셀
     public S3ExcelFileInputStreamDto downloadPossibleTimeTableXlsx() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewPossibleTimeTable);
         HttpHeaders headers = createHttpHeaders(POSSIBLE_TIME_TABLE_FORM_NAME);
@@ -64,6 +66,7 @@ public class S3DownloadSerivce {
         );
     }
 
+    // 면접 시간표 다운로드 (관리자용)
     public S3ExcelFileInputStreamDto downloadInterviewTimeTableForManagerXLSX() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewTimeTableForManager);
         HttpHeaders headers = createHttpHeaders(INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,6 +59,8 @@ cloud:
 final_interview_form: ${FINAL_INTERVIEW_FORM}
 interview_possible_time_table: ${INTERVIEW_POSSIBLE_TIME_TABLE_XLSX}
 interview_time_table_for_manager: ${INTERVIEW_TIME_TABLE_FOR_MANAGER}
+interview_evaluation_initial_form: ${INTERVIEW_EVALUATION_INITIAL_FORM}
+interview_evaluation_xlsx: ${INTERVIEW_EVALUATION_XLSX}
 
 app:
   s3:


### PR DESCRIPTION
## ➕ 연관된 이슈
> #224 
> Close #224

## FLOW 정리

<img width="3225" height="2455" alt="image" src="https://github.com/user-attachments/assets/95fe5e84-108d-4cbb-b620-c155a05c51b2" />


## 📑 작업 내용
> - 면접 평가 엑셀 관련 API 작업을 수행했습니다.

- [ ] 면접 평가 초기 양식 다운로드 API 
- [ ] 질문이 작성된 [면접 평가 시트] 업로드 API
- [ ] 면접 평가 시트 다운로드 API
- [ ] InterviewFinal을 비우는 API

> `평가 초기 양식`, `평가 시트` 엑셀 S3 다운로드 경로는 보안을 위해 환경변수 처리했습니다.


### 질문이 작성된 [면접 평가 시트] 업로드 API

1. 관리자가 초기 양식을 다운로드 받은 뒤 질문을 작성합니다.
2. 질문이 작성된 면접 평가 시트를 업로드합니다.
3. Server에서는 이 평가 시트에 면접자 정보를 삽입하고 S3에 저장합니다.

```java
    public void insertInterviewerAndStoreToS3(MultipartFile file) {
        String generation = applyInitialSetupService.getCurrentGeneration();
        List<InterviewFinal> interviewList = interviewGetService.getInterviewFinalListByGeneration(generation);

        try (Workbook workbook = WorkbookFactory.create(file.getInputStream())) {
            // Excel 에 면접자 정보 작성
            interviewExcelService.writeInterviewerData(workbook, interviewList);
            // S3에 업로드
            s3Service.uploadInterviewEvaluationToS3(workbook);
        } catch (IOException e) {
            throw new RuntimeException("엑셀 파일 처리에 실패했습니다.", e);
        }

    }
```

### InterviewFinal 삭제 API

최종면접 정보인 InterviewFinal은 매 기수마다 비워지고 채워져야합니다.
또한, 한 기수에서 InterveiwFinal을 잘못 올린 경우 지울 수 있도록 해당 API를 구현했습니다.


## ✂️ 스크린샷 (선택)
>

### 면접 평가 시트 다운로드 결과

<img width="1373" height="891" alt="image" src="https://github.com/user-attachments/assets/ea62516a-5f71-41c4-93d0-54a23378f328" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
