### PR TITLE
feat: 대시보드 API 구현 및 테스트 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+
     // redis shedlock
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'
     implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.16.0'

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
@@ -1,0 +1,24 @@
+package com.tave.tavewebsite.domain.apply.dashboard.controller;
+
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardResDto;
+import com.tave.tavewebsite.domain.apply.dashboard.service.DashboardService;
+import com.tave.tavewebsite.global.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.tave.tavewebsite.domain.apply.dashboard.controller.DashboardSuccessMessage.DASHBOARD_SUCCESS_MESSAGE;
+
+@RestController
+@RequestMapping("/v1")
+@RequiredArgsConstructor
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    @GetMapping("/admin/dashboard")
+    public SuccessResponse<DashboardResDto> getDashboard() {
+        return new SuccessResponse<>(dashboardService.getDashboard(), DASHBOARD_SUCCESS_MESSAGE.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardSuccessMessage.java
@@ -1,0 +1,13 @@
+package com.tave.tavewebsite.domain.apply.dashboard.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DashboardSuccessMessage {
+
+    DASHBOARD_SUCCESS_MESSAGE("대시보드를 성공적으로 조회하였습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardRatioResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardRatioResDto.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.apply.dashboard.dto;
+
+public record DashboardRatioResDto(
+        String topic,
+        Long count,
+        double ratio
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardResDto.java
@@ -1,0 +1,12 @@
+package com.tave.tavewebsite.domain.apply.dashboard.dto;
+
+import java.util.List;
+
+public record DashboardResDto(
+        long totalCount,
+        double comparisonRatio,
+        long temperCount,
+        List<DashboardRatioResDto> sexRatioDtos,
+        List<DashboardRatioResDto> fieldRatioDtos
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/entity/Dashboard.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/entity/Dashboard.java
@@ -1,0 +1,96 @@
+package com.tave.tavewebsite.domain.apply.dashboard.entity;
+
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.global.common.FieldType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Dashboard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long totalCount = 0L;
+
+    @Column(nullable = false)
+    private Long previousCount = 0L;
+
+    @Column(nullable = false)
+    private Long comparisonRatio = 0L;
+
+    @Column(nullable = false)
+    private Long maleCount = 0L;
+
+    @Column(nullable = false)
+    private Long femaleCount = 0L;
+
+    @Column(nullable = false)
+    private Long backendCount = 0L;
+
+    @Column(nullable = false)
+    private Long webFrontCount = 0L;
+
+    @Column(nullable = false)
+    private Long designCount = 0L;
+
+    @Column(nullable = false)
+    private Long appFrontCount = 0L;
+
+    @Column(nullable = false)
+    private Long dataAnalysisCount = 0L;
+
+    @Column(nullable = false)
+    private Long deepCount = 0L;
+
+    public Dashboard(Long totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public void initDashboard() {
+        this.previousCount = totalCount;
+        this.totalCount = 0L;
+        this.comparisonRatio = 0L;
+        this.maleCount = 0L;
+        this.femaleCount = 0L;
+        this.backendCount = 0L;
+        this.appFrontCount = 0L;
+        this.designCount = 0L;
+        this.webFrontCount = 0L;
+        this.dataAnalysisCount = 0L;
+        this.deepCount = 0L;
+    }
+
+    public void updateDashboard(Resume resume, Member member) {
+        this.totalCount += 1;
+        if(member.getSex().equals(Sex.MALE)) {
+            this.maleCount += 1;
+        } else this.femaleCount += 1;
+
+        if(resume.getField().equals(FieldType.APPFRONTEND)) {
+            this.appFrontCount += 1;
+        }
+        else if(resume.getField().equals(FieldType.WEBFRONTEND)) {
+            this.webFrontCount += 1;
+        }
+        else if(resume.getField().equals(FieldType.BACKEND)) {
+            this.backendCount += 1;
+        }
+        else if(resume.getField().equals(FieldType.DESIGN)) {
+            this.designCount += 1;
+        }
+        else if(resume.getField().equals(FieldType.DATAANALYSIS))
+            this.dataAnalysisCount += 1;
+        else if(resume.getField().equals(FieldType.DEEPLEARNING))
+            this.deepCount += 1;
+
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/exception/DashboardErrorException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/exception/DashboardErrorException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.apply.dashboard.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.apply.dashboard.exception.DashboardErrorMessage.NOT_FOUND_DASHBOARD;
+
+public class DashboardErrorException extends BaseErrorException {
+    public DashboardErrorException() {
+        super(NOT_FOUND_DASHBOARD.code, NOT_FOUND_DASHBOARD.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/exception/DashboardErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/exception/DashboardErrorMessage.java
@@ -1,0 +1,14 @@
+package com.tave.tavewebsite.domain.apply.dashboard.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DashboardErrorMessage {
+
+    NOT_FOUND_DASHBOARD(404, "대시보드 조회를 불러올 수 없습니다.");
+
+    final int code;
+    final String message;
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardRepository.java
@@ -1,0 +1,7 @@
+package com.tave.tavewebsite.domain.apply.dashboard.repository;
+
+import com.tave.tavewebsite.domain.apply.dashboard.entity.Dashboard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/service/DashboardService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/service/DashboardService.java
@@ -1,0 +1,81 @@
+package com.tave.tavewebsite.domain.apply.dashboard.service;
+
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardRatioResDto;
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardResDto;
+import com.tave.tavewebsite.domain.apply.dashboard.entity.Dashboard;
+import com.tave.tavewebsite.domain.apply.dashboard.exception.DashboardErrorException;
+import com.tave.tavewebsite.domain.apply.dashboard.repository.DashboardRepository;
+import com.tave.tavewebsite.domain.member.entity.Member;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import com.tave.tavewebsite.global.redis.utils.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final DashboardRepository dashboardRepository;
+    private final RedisUtil redisUtil;
+
+    public DashboardResDto getDashboard() {
+        Dashboard dashboard = findIfExists();
+        double generationRatio = dashboard.getTotalCount() == 0 ? 0.0 :
+                (double) (dashboard.getTotalCount() - dashboard.getPreviousCount()) / dashboard.getTotalCount() * 100;
+        long tempCount = redisUtil.countResumeKeysWithPrefix();
+
+        Long totalCount = dashboard.getTotalCount();
+        List<DashboardRatioResDto> dashboardRatioResDtosBySex = extractedSexDto(totalCount, dashboard);
+        List<DashboardRatioResDto> dashboardRatioResDtosByField = extractedFieldDto(totalCount, dashboard);
+
+        return new DashboardResDto(totalCount, generationRatio, tempCount,
+                dashboardRatioResDtosBySex, dashboardRatioResDtosByField);
+    }
+
+    private List<DashboardRatioResDto> extractedFieldDto(Long totalCount, Dashboard dashboard) {
+        return List.of(
+                new DashboardRatioResDto("앱프론트", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getAppFrontCount())),
+                new DashboardRatioResDto("웹프론트", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getWebFrontCount())),
+                new DashboardRatioResDto("백엔드", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getBackendCount())),
+                new DashboardRatioResDto("디자인", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getDesignCount())),
+                new DashboardRatioResDto("데이터분석", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getDataAnalysisCount())),
+                new DashboardRatioResDto("딥러닝", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getDeepCount()))
+        );
+    }
+
+    private List<DashboardRatioResDto> extractedSexDto(Long totalCount, Dashboard dashboard) {
+        return List.of(
+                new DashboardRatioResDto("남성", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getMaleCount())),
+                new DashboardRatioResDto("여성", totalCount, getRatio(dashboard.getTotalCount(), dashboard.getFemaleCount()))
+        );
+    }
+
+    // 지원 초기 설정 시 대시보드도 초기화
+    @Transactional
+    public void initDashboard() {
+        if(dashboardRepository.existsById(1L)){
+            dashboardRepository.findById(1L).ifPresent(Dashboard::initDashboard);
+            return;
+        }
+        Dashboard dashboard = new Dashboard(0L);
+        dashboardRepository.save(dashboard);
+    }
+
+    @Transactional
+    public void addDetailedCount(Resume resume, Member member) {
+        Dashboard dashboard = findIfExists();
+        dashboard.updateDashboard(resume, member);
+    }
+
+    private Dashboard findIfExists() {
+        return dashboardRepository.findById(1L).orElseThrow(DashboardErrorException::new);
+    }
+
+    private double getRatio(Long totalCount, Long count){
+        if (totalCount == null || totalCount == 0) return 0.0;
+        return ((double) count / totalCount) * 100;
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.apply.initial.setup.service;
 
+import com.tave.tavewebsite.domain.apply.dashboard.service.DashboardService;
 import com.tave.tavewebsite.domain.apply.initial.setup.dto.request.ApplyInitialSetupRequestDto;
 import com.tave.tavewebsite.domain.apply.initial.setup.dto.response.ApplyInitialSetupReadResponseDto;
 import com.tave.tavewebsite.domain.apply.initial.setup.entity.ApplyInitialSetup;
@@ -8,13 +9,12 @@ import com.tave.tavewebsite.domain.apply.initial.setup.repository.ApplyInitialSe
 import com.tave.tavewebsite.domain.apply.initial.setup.util.ApplyInitialSetUpMapper;
 import com.tave.tavewebsite.domain.resume.batch.exception.RecruitmentBatchJobException.DocumentResultBatchJobFailException;
 import jakarta.servlet.http.HttpServletRequest;
-
-import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ApplyInitialSetupService {
 
     private final ApplyInitialSetupRepository applyInitialSetupRepository;
+    private final DashboardService dashboardService;
 
     @Transactional(readOnly = true)
     public ApplyInitialSetupReadResponseDto getInitialSetup() {
@@ -32,6 +33,7 @@ public class ApplyInitialSetupService {
     }
 
     public void saveInitialSetup(ApplyInitialSetupRequestDto dto) {
+        dashboardService.initDashboard(); // 대시보드 초기화
         if (applyInitialSetupRepository.existsById(1L)) {
             Optional<ApplyInitialSetup> byId = applyInitialSetupRepository.findById(1L);
             byId.get().updateFrom(dto);

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeEvaluateController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeEvaluateController.java
@@ -37,7 +37,7 @@ public class ResumeEvaluateController {
     // 서류 리스트 보기
     @GetMapping
     public SuccessResponse<ResumeEvaluateResDto> getDocumentEvaluationList(
-            @RequestParam EvaluationStatus status,
+            @RequestParam(required = false) EvaluationStatus status,
             @PageableDefault(size = 7) Pageable pageable
     ) {
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.applicant.history.entity.ApplicantHistory;
 import com.tave.tavewebsite.domain.applicant.history.entity.ApplicationStatus;
 import com.tave.tavewebsite.domain.applicant.history.repository.ApplicantHistoryRepository;
 import com.tave.tavewebsite.domain.applicant.history.service.ApplicantHistoryService;
+import com.tave.tavewebsite.domain.apply.dashboard.service.DashboardService;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
@@ -32,9 +33,10 @@ import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import com.tave.tavewebsite.global.common.FieldType;
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +50,7 @@ public class PersonalInfoService {
     private final ApplicantHistoryRepository applicantHistoryRepository;
     private final ApplicantHistoryService applicantHistoryService;
     private final ResumeQuestionRepository resumeQuestionRepository;
+    private final DashboardService dashboardService;
 
     private final RedisUtil redisUtil;
 
@@ -195,6 +198,7 @@ public class PersonalInfoService {
         Resume resume = getResumeEntityById(resumeId);
         resume.submit();
         resumeRepository.save(resume);
+        dashboardService.addDetailedCount(resume, resume.getMember());
     }
 
     public List<TimeSlotResDto> getInterviewTime() {

--- a/src/main/java/com/tave/tavewebsite/global/redisson/RedissonConfig.java
+++ b/src/main/java/com/tave/tavewebsite/global/redisson/RedissonConfig.java
@@ -1,0 +1,20 @@
+package com.tave.tavewebsite.global.redisson;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redisson() throws IOException {
+        Config config = Config.fromYAML(new ClassPathResource("redisson.yaml").getInputStream());
+        return Redisson.create(config);
+    }
+}

--- a/src/main/resources/redisson.yaml
+++ b/src/main/resources/redisson.yaml
@@ -1,0 +1,8 @@
+singleServerConfig:
+  address: "redis://${REDIS_HOST}:${REDIS_PORT}"
+  password: "${REDIS_PASSWORD}"
+  connectionPoolSize: 64
+  connectionMinimumIdleSize: 24
+  timeout: 10000
+threads: 4
+nettyThreads: 8


### PR DESCRIPTION
## ➕ 연관된 이슈
> #226 
> Close #226 

## 📑 작업 내용
> - 기수 지원 기간 동안의 현황을 한눈에 보기 위해 필요한 대시보드 기능을 구현하였습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
