### PR TITLE
[feat] 지원자 본인 확인용 지원서 조회 기능 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeQuestionController.java
@@ -2,6 +2,7 @@ package com.tave.tavewebsite.domain.resume.controller;
 
 import com.tave.tavewebsite.domain.resume.dto.request.ResumeReqDto;
 import com.tave.tavewebsite.domain.resume.dto.response.DetailResumeQuestionResponse;
+import com.tave.tavewebsite.domain.resume.dto.response.ResumeDetailResponse;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.service.PersonalInfoService;
 import com.tave.tavewebsite.domain.resume.service.ResumeQuestionService;
@@ -38,6 +39,12 @@ public class ResumeQuestionController {
     ) {
         Resume resume = personalInfoService.getResumeEntityById(resumeId);
         List<DetailResumeQuestionResponse> response = resumeQuestionService.getResumeQuestionPage(resume, page);
+        return new SuccessResponse<>(response, QUESTION_READ_SUCCESS.getMessage());
+    }
+
+    @GetMapping("/{resumeId}/details")
+    public SuccessResponse<ResumeDetailResponse> getResumeDetails(@PathVariable Long resumeId) {
+        ResumeDetailResponse response = resumeQuestionService.getResumeDetail(resumeId);
         return new SuccessResponse<>(response, QUESTION_READ_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/CommonResumeResponse.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.resume.dto.response;
 
+import com.tave.tavewebsite.domain.resume.dto.timeslot.TimeSlotResDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 
 import java.util.List;
@@ -9,8 +10,9 @@ public record CommonResumeResponse(
         String blogUrl,
         String githubUrl,
         String portfolioUrl,
-        List<DetailResumeQuestionResponse> commonQuestions
-) {
+        List<DetailResumeQuestionResponse> commonQuestions,
+        List<TimeSlotResDto> timeSlots
+        ) {
     public static CommonResumeResponse of(Resume resume,
                                           List<DetailResumeQuestionResponse> commonQuestions) {
         return new CommonResumeResponse(
@@ -18,7 +20,10 @@ public record CommonResumeResponse(
                 resume.getBlogUrl(),
                 resume.getGithubUrl(),
                 resume.getPortfolioUrl(),
-                commonQuestions
+                commonQuestions,
+                resume.getResumeTimeSlots().stream()
+                        .map(TimeSlotResDto::from)
+                        .toList()
         );
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeDetailResponse.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeDetailResponse.java
@@ -1,0 +1,25 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import com.tave.tavewebsite.domain.programinglaunguage.dto.response.LanguageLevelResponseDto;
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+
+import java.util.List;
+
+public record ResumeDetailResponse(
+        Long resumeId,
+        CommonResumeResponse common,
+        SpecificResumeResponseDto specific,
+        ResumeMemberInfoDto member
+) {
+    public static ResumeDetailResponse of(Resume resume,
+                                          List<DetailResumeQuestionResponse> commonQuestions,
+                                          List<DetailResumeQuestionResponse> specificQuestions,
+                                          List<LanguageLevelResponseDto> languageLevels) {
+        return new ResumeDetailResponse(
+                resume.getId(),
+                CommonResumeResponse.of(resume, commonQuestions),
+                SpecificResumeResponseDto.of(resume.getId(), specificQuestions, languageLevels),
+                ResumeMemberInfoDto.of(resume)
+        );
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -68,6 +68,9 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
     })
     List<Resume> findAllWithRelationsByIdIn(List<Long> resumeIds);
 
+    @EntityGraph(attributePaths = {"resumeTimeSlots"})
+    Optional<Resume> findWithTimeSlotsById(Long id);
+
     // 가짓수가 많은 TimeSlot은 Fetch, Member는 ManyToOne 관계이므로 Fetch 사용 무방
     @Query("SELECT DISTINCT r FROM Resume r " +
             "LEFT JOIN FETCH r.resumeTimeSlots " +

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -230,4 +230,29 @@ public class ResumeQuestionService {
     public List<ResumeQuestion> getResumeListByResumeId(Long resumeId) {
         return resumeQuestionRepository.findByResumeId(resumeId);
     }
+
+    @Transactional(readOnly = true)
+    public ResumeDetailResponse getResumeDetail(Long resumeId) {
+        Resume resume = resumeRepository.findWithTimeSlotsById(resumeId)
+                .orElseThrow(() -> new ResumeNotFoundException());
+
+        List<DetailResumeQuestionResponse> commonQuestions = new ArrayList<>();
+        List<DetailResumeQuestionResponse> specificQuestions = new ArrayList<>();
+
+        for (ResumeQuestion rq : resume.getResumeQuestions()) {
+            DetailResumeQuestionResponse dto = DetailResumeQuestionResponse.from(rq);
+            if (rq.getFieldType() == FieldType.COMMON) {
+                commonQuestions.add(dto);
+            } else {
+                specificQuestions.add(dto);
+            }
+        }
+
+        List<LanguageLevelResponseDto> languageLevels = resume.getProgramingLanguages().stream()
+                .map(LanguageLevelResponseDto::fromEntity)
+                .toList();
+
+        return ResumeDetailResponse.of(resume, commonQuestions, specificQuestions, languageLevels);
+    }
+
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #240
> Close #240

## 📑 작업 내용
> - 지원자 본인 확인용 지원서 조회에는 질문과 답변, 소셜주소, 면접시간, 프로그래밍 레벨 모두를 조회해야 합니다.
> - 지원서 상세 조회를 위한 `ResumeDetailResponse` 를 추가했습니다.
> - 서비스 계층에서 분야별 질문과 공통 질문을 모두 조회하도록 개선했습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
