### PR TITLE
[feat] 지원자 이름 검색 기능 위해 "name" 파라미터 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeEvaluateController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeEvaluateController.java
@@ -40,11 +40,12 @@ public class ResumeEvaluateController {
     public SuccessResponse<ResumeEvaluateResDto> getDocumentEvaluationList(
             @RequestParam(required = false) EvaluationStatus status,
             @RequestParam(required = false) FieldType type,
+            @RequestParam(required = false) String name,
             @PageableDefault(size = 7) Pageable pageable
     ) {
 
         return new SuccessResponse<>(
-                resumeEvaluateService.getDocumentResumes(status, type, pageable),
+                resumeEvaluateService.getDocumentResumes(status, type, name, pageable),
                 READ_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface ResumeCustomRepository {
 
-    Page<ResumeResDto> findMiddleEvaluation(Member member, EvaluationStatus status, FieldType type, Pageable pageable);
+    Page<ResumeResDto> findMiddleEvaluation(Member member, EvaluationStatus status, FieldType type, String name, Pageable pageable);
 
     Page<ResumeResDto> findFinalEvaluation(Member member, EvaluationStatus status, FieldType type, Pageable pageable);
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepositoryImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepositoryImpl.java
@@ -98,7 +98,7 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
 
     private BooleanExpression extractedStatus(EvaluationStatus status) {
         if (status == null)
-            return Expressions.asBoolean(true).isTrue(); // 항상 참 반환
+            return null;
         if (status == EvaluationStatus.NOTCHECKED) {
             return resumeEvaluation.finalEvaluateDocument.isNull();
         } else {

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepositoryImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeCustomRepositoryImpl.java
@@ -32,18 +32,23 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ResumeResDto> findMiddleEvaluation(Member member, EvaluationStatus status, FieldType type, Pageable pageable) {
+    public Page<ResumeResDto> findMiddleEvaluation(Member member, EvaluationStatus status, FieldType type, String name, Pageable pageable) {
         QResumeEvaluation resumeEvaluationSub = new QResumeEvaluation("reSub");
 
         BooleanBuilder condition = new BooleanBuilder();
         BooleanExpression statusCondition = extractedStatus(status);
         BooleanExpression typeCondition = extractedFieldType(type);
+        BooleanExpression nameCondition = extractedName(name);
 
         if (statusCondition != null) {
             condition.and(statusCondition);
         }
         if (typeCondition != null) {
             condition.and(typeCondition);
+        }
+
+        if (nameCondition != null) {
+            condition.and(nameCondition);
         }
 
         List<ResumeResDto> resumeResDtos = queryFactory
@@ -68,7 +73,7 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
                 .leftJoin(resumeEvaluation)
                 .on(
                         resumeEvaluation.resume.id.eq(resume.id)
-                        .and(resumeEvaluation.member.id.eq(member.getId()))
+                                .and(resumeEvaluation.member.id.eq(member.getId()))
                 )
                 .where(condition)
                 .offset(pageable.getOffset())
@@ -92,28 +97,30 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
     }
 
     private BooleanExpression extractedStatus(EvaluationStatus status) {
-        BooleanExpression condition;
-
-        if(status == null)
-            return null;
-
+        if (status == null)
+            return Expressions.asBoolean(true).isTrue(); // 항상 참 반환
         if (status == EvaluationStatus.NOTCHECKED) {
-            condition = resumeEvaluation.finalEvaluateDocument.isNull();
+            return resumeEvaluation.finalEvaluateDocument.isNull();
         } else {
-            condition = resumeEvaluation.finalEvaluateDocument.eq(status);
+            return resumeEvaluation.finalEvaluateDocument.eq(status);
         }
-
-        return condition;
     }
 
     private BooleanExpression extractedFieldType(FieldType type) {
         BooleanExpression fieldType;
 
-        if(type == null)
+        if (type == null)
             return null;
         fieldType = resume.field.eq(type);
 
         return fieldType;
+    }
+
+    private BooleanExpression extractedName(String name) {
+        if (name == null || name.isBlank()) {
+            return null;
+        }
+        return resume.member.username.containsIgnoreCase(name);
     }
 
     // 해당 조회는 EvaluationStatus 값이 평가 완료 or 평가 진행 전일 경우에 둘다 평가 진행 전으로 처리
@@ -162,7 +169,7 @@ public class ResumeCustomRepositoryImpl implements ResumeCustomRepository {
     private BooleanExpression extractedStatusInFinalEvaluation(EvaluationStatus status) {
         BooleanExpression condition;
 
-        if(status == null)
+        if (status == null)
             return null;
 
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeEvaluateService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeEvaluateService.java
@@ -29,20 +29,19 @@ public class ResumeEvaluateService {
     private final ResumeEvaluationRepository resumeEvaluationRepository;
     private final ResumeRepository resumeRepository;
 
-    public Member getCurrentMember(){
+    public Member getCurrentMember() {
         return SecurityUtils.getCurrentMember();
     }
 
     @Transactional
-    public void createDocumentEvaluation(Long resumeId, DocumentEvaluationReqDto documentEvaluationReqDto){
+    public void createDocumentEvaluation(Long resumeId, DocumentEvaluationReqDto documentEvaluationReqDto) {
         Resume resume = findIfResumeExists(resumeId);
         Member currentMember = getCurrentMember();
 
-        if(resumeEvaluationRepository.existsByMemberIdAndResumeId(currentMember.getId(), resumeId)){
+        if (resumeEvaluationRepository.existsByMemberIdAndResumeId(currentMember.getId(), resumeId)) {
             ResumeEvaluation evaluation = resumeEvaluationRepository.findByMemberIdAndResumeId(currentMember.getId(), resumeId);
             evaluation.update(documentEvaluationReqDto);
-        }
-        else {
+        } else {
             ResumeEvaluation resumeEvaluation = ResumeEvaluation.of(documentEvaluationReqDto, currentMember, resume);
             resumeEvaluationRepository.save(resumeEvaluation);
         }
@@ -50,13 +49,12 @@ public class ResumeEvaluateService {
 
     //본인 기반의 작성한 지원서에 대해 조회해야됨
     @Transactional(readOnly = true)
-    public ResumeEvaluateResDto getDocumentResumes(EvaluationStatus status, FieldType type, Pageable pageable) {
+    public ResumeEvaluateResDto getDocumentResumes(EvaluationStatus status, FieldType type, String name, Pageable pageable) {
         Member currentMember = getCurrentMember();
-        Page<ResumeResDto> resumeResDtos = resumeRepository.findMiddleEvaluation(currentMember, status, type, pageable);
+        Page<ResumeResDto> resumeResDtos = resumeRepository.findMiddleEvaluation(currentMember, status, type, name, pageable);
 
-
-
-        return ResumeEvaluateResDto.fromResume(resumeRepository.count(),
+        return ResumeEvaluateResDto.fromResume(
+                resumeRepository.count(),
                 resumeRepository.findNotEvaluatedResume(currentMember),
                 resumeRepository.findEvaluatedResume(currentMember),
                 resumeResDtos);
@@ -75,7 +73,7 @@ public class ResumeEvaluateService {
     }
 
     @Transactional
-    public void createFinalDocumentEvaluation(Long resumeId, FinalDocumentEvaluationReqDto reqDto){
+    public void createFinalDocumentEvaluation(Long resumeId, FinalDocumentEvaluationReqDto reqDto) {
         Resume resume = findIfResumeExists(resumeId);
         resume.updateFinalDocumentEvaluationStatus(reqDto.status());
     }
@@ -92,7 +90,7 @@ public class ResumeEvaluateService {
     }
 
     @Transactional
-    public void deleteAllResume(){
+    public void deleteAllResume() {
         resumeRepository.deleteAll();
     }
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #245
> Close #245

## 📑 작업 내용
> - 기존 서류 리스트 조회 api에 `name` 파라미터를 추가했습니다.

```
if (status == null)
    return null;
```
이전 코드에서는 `extractedStatus()` 메서드에서 `status`가 null일 때 null을 반환하였는데, 
```
BooleanExpression statusCondition = extractedStatus(status);
if (statusCondition != null) {
    condition.and(statusCondition);
}
```
위 코드처럼 null 체크를 하였더라도 `BooleanExpression` 타입 변수를 바로 `.and()` 하는 코드가 있으면, null 값에서 `.and()`를 호출하면서 `NullPointerException`이 발생할 수 있는 문제점이 있었습니다.

```
if (status == null)
    return Expressions.asBoolean(true).isTrue(); // 항상 참 반환
```
때문에 null 대신에 항상 참인 조건 (true)을 반환하도록 하여 쿼리에서 아무런 영향을 주지 않고, null 반환으로 인한 `.and()` 호출 시 발생하는 `NullPointerException`을 예방할 수 있도록 수정하였습니다.


## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
