### PR TITLE
[fix] 최종합격 설정 시 기존 내용 삭제 후 최신 내용 조회

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/controller/FinalPassController.java
@@ -18,9 +18,9 @@ public class FinalPassController {
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.CREATE_FINAL_PASS.getMessage());
     }
 
-    @GetMapping("/v1/member/final-pass/{id}")
-    public SuccessResponse<FinalPassResponseDto> getFinalPass(@PathVariable Long id) {
-        FinalPassResponseDto dto = finalPassService.getFinalPass(id);
+    @GetMapping("/v1/member/final-pass")
+    public SuccessResponse<FinalPassResponseDto> getFinalPass() {
+        FinalPassResponseDto dto = finalPassService.getFinalPass();
         return new SuccessResponse<>(dto, FinalPassSuccessMessage.READ_FINAL_PASS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/repository/FinalPassRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/repository/FinalPassRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface FinalPassRepository extends JpaRepository<FinalPass, Long> {
+    Optional<FinalPass> findTopByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/finalpass/service/FinalPassService.java
@@ -17,14 +17,16 @@ public class FinalPassService {
 
     @Transactional
     public FinalPassResponseDto createFinalPass(FinalPassRequestDto dto) {
+        finalPassRepository.deleteAll();
+
         FinalPass entity = FinalPassMapper.toEntity(dto);
         finalPassRepository.save(entity);
         return FinalPassMapper.toResponseDto(entity);
     }
 
     @Transactional(readOnly = true)
-    public FinalPassResponseDto getFinalPass(Long id) {
-        FinalPass entity = finalPassRepository.findById(id)
+    public FinalPassResponseDto getFinalPass() {
+        FinalPass entity = finalPassRepository.findTopByOrderByCreatedAtDesc()
                 .orElseThrow(FinalPassNotFoundException::new);
         return FinalPassMapper.toResponseDto(entity);
     }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #251 
> Close #251 

## 📑 작업 내용
> - 최종합격 설정 (POST) 시 기존에 설정한 내역은 삭제하고 최신 등록한 내용만 DB에 남깁니다.
> - 최종합격 조회 (GET) 시 최신 내역만 조회 가능합니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
