### PR TITLE
[feat] 로그인 시 resumeId 응답에 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/dto/response/SignInResponseDto.java
@@ -17,9 +17,10 @@ public record SignInResponseDto(
         String generation,
         DepartmentType department,
         JobType job,
-        ResumeState resumeState
+        ResumeState resumeState,
+        Long resumeId
 ) {
-    public static SignInResponseDto from(JwtToken token, Member member, ResumeState resumeState) {
+    public static SignInResponseDto from(JwtToken token, Member member, ResumeState resumeState, Long resumeId) {
         return new SignInResponseDto(token.getGrantType(),
                 token.getAccessToken(),
                 member.getId(),
@@ -30,6 +31,7 @@ public record SignInResponseDto(
                 member.getGeneration(),
                 member.getDepartment(),
                 member.getJob(),
-                resumeState);
+                resumeState,
+                resumeId);
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -47,10 +47,16 @@ public class AuthService {
         Member member = memberRepository.findByEmail(requestDto.email())
                 .orElseThrow(NotFoundMemberException::new);
 
-        ResumeState resumeState = resumeRepository.findByMemberId(member.getId())
-                .map(Resume::getState)
-                .orElse(ResumeState.TEMPORARY);
-        return SignInResponseDto.from(jwtToken, member, resumeState);
+//        ResumeState resumeState = resumeRepository.findByMemberId(member.getId())
+//                .map(Resume::getState)
+//                .orElse(ResumeState.TEMPORARY);
+        // 작성한 지원서 조회
+        Resume resume = resumeRepository.findByMemberId(member.getId()).orElse(null);
+        ResumeState resumeState = (resume != null) ? resume.getState() : ResumeState.TEMPORARY;
+
+        Long resumeId = (resume != null) ? resume.getId() : 0L;  // 지원서 없으면 0
+
+        return SignInResponseDto.from(jwtToken, member, resumeState, resumeId);
     }
 
     public void signOut(String accessToken, HttpServletResponse response) {

--- a/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/member/service/AuthService.java
@@ -47,10 +47,6 @@ public class AuthService {
         Member member = memberRepository.findByEmail(requestDto.email())
                 .orElseThrow(NotFoundMemberException::new);
 
-//        ResumeState resumeState = resumeRepository.findByMemberId(member.getId())
-//                .map(Resume::getState)
-//                .orElse(ResumeState.TEMPORARY);
-        // 작성한 지원서 조회
         Resume resume = resumeRepository.findByMemberId(member.getId()).orElse(null);
         ResumeState resumeState = (resume != null) ? resume.getState() : ResumeState.TEMPORARY;
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #254 
> Close #254 

## 📑 작업 내용
> - 로그인 시 응답에 `resumeId` 필드를 추가했습니다.
> - 작성한 지원서가 없으면 0, 있다면 해당 `resumeId` 를 가져오도록 했습니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
