### PR TITLE
[refactor] 임시저장, 소셜주소 사용자 검증 로직 추가

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeAnswerTempController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeAnswerTempController.java
@@ -4,6 +4,7 @@ import com.tave.tavewebsite.domain.resume.controller.message.PersonalInfoSuccess
 import com.tave.tavewebsite.domain.resume.dto.request.ResumeReqDto;
 import com.tave.tavewebsite.domain.resume.dto.wrapper.ResumeTempWrapper;
 import com.tave.tavewebsite.domain.resume.service.ResumeAnswerTempService;
+import com.tave.tavewebsite.global.security.utils.SecurityUtils;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,14 +23,16 @@ public class ResumeAnswerTempController {
     public SuccessResponse saveTempAnswers(@PathVariable(name = "resumeId") Long resumeId,
                                            @RequestParam(name = "page") int page,
                                            @RequestBody ResumeReqDto tempDto) {
-        tempService.tempSaveAnswers(resumeId, page, tempDto);
+        Long memberId = SecurityUtils.getCurrentMember().getId();
+        tempService.tempSaveAnswers(resumeId, page, tempDto, memberId);
         return SuccessResponse.ok(TEMP_SAVE_SUCCESS.getMessage());
     }
 
     // 전체 임시 저장 객체 조회
     @GetMapping("/{resumeId}")
     public SuccessResponse<ResumeTempWrapper> getTempAnswers(@PathVariable(name = "resumeId") Long resumeId) {
-        ResumeTempWrapper response = tempService.getTempSavedAnswers(resumeId);
+        Long memberId = SecurityUtils.getCurrentMember().getId();
+        ResumeTempWrapper response = tempService.getTempSavedAnswers(resumeId, memberId);
         return new SuccessResponse<>(response, PersonalInfoSuccessMessage.TEMP_LOAD_SUCCESS.getMessage());
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/SocialLinksController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/SocialLinksController.java
@@ -30,16 +30,7 @@ public class SocialLinksController {
                                                @RequestBody SocialLinksRequestDto socialLinksRequestDto) {
         Long memberId = SecurityUtils.getCurrentMember().getId();
         socialLinksService.createSocialLinks(resumeId, socialLinksRequestDto, memberId);
-        socialLinksService.saveSocialLinksToRedis(resumeId, socialLinksRequestDto, memberId);
         return SuccessResponse.ok(SocialLinksSuccessMessage.CREATE_SUCCESS.getMessage());
-    }
-
-    // 소셜 링크 조회
-    @GetMapping("/social-links")
-    public SuccessResponse<SocialLinksResponseDto> getSocialLinks(@PathVariable("resumeId") Long resumeId) {
-        Long memberId = SecurityUtils.getCurrentMember().getId();
-        SocialLinksResponseDto dto = socialLinksService.getSocialLinks(resumeId, memberId);
-        return new SuccessResponse<>(dto, SocialLinksSuccessMessage.READ_SUCCESS.getMessage());
     }
 
     // 소셜 링크 업데이트
@@ -48,7 +39,6 @@ public class SocialLinksController {
                                              @RequestBody SocialLinksRequestDto socialLinksRequestDto) {
         Long memberId = SecurityUtils.getCurrentMember().getId();
         socialLinksService.updateSocialLinks(resumeId, socialLinksRequestDto, memberId);
-        socialLinksService.saveSocialLinksToRedis(resumeId, socialLinksRequestDto, memberId);
         return SuccessResponse.ok(SocialLinksSuccessMessage.UPDATE_SUCCESS.getMessage());
     }
 
@@ -62,11 +52,11 @@ public class SocialLinksController {
         URL portfolioUrl = s3Service.uploadFile(file);
 
         socialLinksService.updatePortfolio(resumeId, portfolioUrl.toString(), memberId);
-        socialLinksService.savePortfolioToRedis(resumeId, portfolioUrl.toString(), memberId);
         PortfolioUploadResponseDto responseDto = new PortfolioUploadResponseDto(portfolioUrl.toString());
         return new SuccessResponse<>(responseDto, SocialLinksSuccessMessage.UPLOAD_SUCCESS.getMessage());
     }
 
+    // 소셜주소 + 포폴 url 조회
     @GetMapping("/social-links/detail")
     public SuccessResponse<SocialLinksResponseDto> getSocialLinksDetail(@PathVariable("resumeId") Long resumeId) {
         Long memberId = SecurityUtils.getCurrentMember().getId();

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/SocialLinksResponseDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/SocialLinksResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SocialLinksResponseDto {
+    private Long memberId;
     private String blogUrl;
     private String githubUrl;
     private String portfolioUrl;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/wrapper/ResumeTempWrapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/wrapper/ResumeTempWrapper.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ResumeTempWrapper {
+    private Long memberId;
     private ResumeReqDto page2;
     private ResumeReqDto page3;
     private int lastPage;

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/wrapper/ResumeTempWrapper.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/wrapper/ResumeTempWrapper.java
@@ -15,4 +15,13 @@ public class ResumeTempWrapper {
     private ResumeReqDto page2;
     private ResumeReqDto page3;
     private int lastPage;
+
+    public static ResumeTempWrapper empty(Long memberId) {
+        return ResumeTempWrapper.builder()
+                .memberId(memberId)
+                .page2(ResumeReqDto.empty())
+                .page3(ResumeReqDto.empty())
+                .lastPage(1)
+                .build();
+    }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/ErrorMessage.java
@@ -30,6 +30,7 @@ public enum ErrorMessage {
     TEMP_SERIALIZE_FAILED(500, "임시 저장 데이터를 JSON으로 변환하는 데 실패했습니다."),
     TEMP_SAVE_FAILED(500, "임시 저장 데이터를 Redis에 저장하는 데 실패했습니다."),
     TEMP_READ_FAILED(500, "임시 저장 데이터를 Redis에서 읽는 데 실패했습니다."),
+    INVALID_DATA_OWNER(403, "현재 사용자와 일치하지 않는 데이터입니다."),
 
     // Resume Evaluation
     ALREADY_EXISTS_EVALUATION(400, "이미 평가중인 이력서입니다."),

--- a/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidDataOwnerException.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/exception/InvalidDataOwnerException.java
@@ -1,0 +1,11 @@
+package com.tave.tavewebsite.domain.resume.exception;
+
+import com.tave.tavewebsite.global.exception.BaseErrorException;
+
+import static com.tave.tavewebsite.domain.resume.exception.ErrorMessage.INVALID_DATA_OWNER;
+
+public class InvalidDataOwnerException extends BaseErrorException {
+    public InvalidDataOwnerException() {
+        super(INVALID_DATA_OWNER.getCode(), INVALID_DATA_OWNER.getMessage());
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
@@ -139,12 +139,7 @@ public class ResumeAnswerTempService {
 
         } catch (Exception e) {
             // Redis 접근 자체가 실패한 경우 → 기본 빈 wrapper 반환
-            ResumeTempWrapper fallback = new ResumeTempWrapper();
-            fallback.setMemberId(memberId); // Redis 실패 시 fallback에도 세팅
-            fallback.setPage2(ResumeReqDto.empty());
-            fallback.setPage3(ResumeReqDto.empty());
-            fallback.setLastPage(1);
-            return fallback;
+            return ResumeTempWrapper.empty(memberId);
         }
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
@@ -1,17 +1,11 @@
 package com.tave.tavewebsite.domain.resume.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tave.tavewebsite.domain.resume.dto.request.ResumeReqDto;
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
 import com.tave.tavewebsite.domain.resume.dto.response.SocialLinksResponseDto;
-import com.tave.tavewebsite.domain.resume.dto.wrapper.ResumeTempWrapper;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.exception.InvalidDataOwnerException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
-import com.tave.tavewebsite.domain.resume.exception.TempParseFailedException;
-import com.tave.tavewebsite.domain.resume.exception.TempSaveFailedException;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
-import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,62 +13,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocialLinksService {
 
     private final ResumeRepository resumeRepository;
-    private final RedisUtil redisUtil;
-    private final ObjectMapper objectMapper;
-    private final ResumeAnswerTempService resumeAnswerTempService;
 
-    public SocialLinksService(ResumeRepository resumeRepository, RedisUtil redisUtil, ObjectMapper objectMapper, ResumeAnswerTempService resumeAnswerTempService) {
+    public SocialLinksService(ResumeRepository resumeRepository) {
         this.resumeRepository = resumeRepository;
-        this.redisUtil = redisUtil;
-        this.objectMapper = objectMapper;
-        this.resumeAnswerTempService = resumeAnswerTempService;
     }
 
-    // ResumeTempWrapper에 접근해서 page3 갱신하는 로직
+    // 소셜 주소 등록
+    @Transactional
     public void createSocialLinks(Long resumeId, SocialLinksRequestDto dto, Long memberId) {
         Resume resume = getAuthorizedResume(resumeId, memberId);
-
         resume.updateSocialLinks(dto);
-
-        // Redis에서 기존 temp wrapper 조회
-        updatePage3WithPreservedTimeSlots(resumeId, memberId);
     }
 
-    // 소셜 링크 조회
     public SocialLinksResponseDto getSocialLinks(Long resumeId, Long memberId) {
-        String portfolioUrl = getPortfolioFromRedisOrDb(resumeId, memberId);
-
-        try {
-            String redisKey = "resume:" + resumeId + ":socialLinks";
-            String redisJson = (String) redisUtil.get(redisKey);
-
-            if (redisJson != null) {
-                try {
-                    SocialLinksRequestDto dto = objectMapper.readValue(redisJson, SocialLinksRequestDto.class);
-                    getAuthorizedResume(resumeId, memberId);
-                    return new SocialLinksResponseDto(memberId, dto.getBlogUrl(), dto.getGithubUrl(), portfolioUrl);
-                } catch (Exception parseError) {
-                    // JSON 파싱 실패 → fallback
-                }
-            }
-        } catch (Exception redisError) {
-            // Redis 접근 실패 → fallback
-        }
-
-        // DB fallback
         Resume resume = getAuthorizedResume(resumeId, memberId);
-
-        // Redis에 다시 저장
-        SocialLinksRequestDto fallbackDto = new SocialLinksRequestDto(
-                resume.getBlogUrl(), resume.getGithubUrl()
-        );
-        saveSocialLinksToRedis(resumeId, fallbackDto, memberId);
-
         return new SocialLinksResponseDto(
                 memberId,
                 resume.getBlogUrl(),
                 resume.getGithubUrl(),
-                portfolioUrl
+                resume.getPortfolioUrl()
         );
     }
 
@@ -82,72 +39,13 @@ public class SocialLinksService {
     @Transactional
     public void updateSocialLinks(Long resumeId, SocialLinksRequestDto dto, Long memberId) {
         Resume resume = getAuthorizedResume(resumeId, memberId);
-
         resume.updateSocialLinks(dto);
-
-        ResumeReqDto page3 = new ResumeReqDto(null, null, null);
-
-        resumeAnswerTempService.tempSaveAnswers(resumeId, 3, page3, memberId); // Redis에도 저장
     }
 
     public void updatePortfolio(Long resumeId, String portfolioUrl, Long memberId) {
         Resume resume = getAuthorizedResume(resumeId, memberId);
-
         resume.updatePortfolio(portfolioUrl);
         resumeRepository.save(resume);
-
-        // Redis에서 기존 temp wrapper 조회
-        updatePage3WithPreservedTimeSlots(resumeId, memberId);
-    }
-
-    // Redis에 임시 저장
-    public void saveSocialLinksToRedis(Long resumeId, SocialLinksRequestDto dto, Long memberId) {
-        try {
-            String key = "resume:" + resumeId + ":member:" + memberId + ":socialLinks";
-            String value = objectMapper.writeValueAsString(dto);
-            redisUtil.set(key, value, 2592000);
-        } catch (Exception e) {
-            throw new TempSaveFailedException();
-        }
-    }
-
-    public void savePortfolioToRedis(Long resumeId, String portfolioUrl, Long memberId) {
-        try {
-            String key = "resume:" + resumeId + ":member:" + memberId + ":portfolioUrl";
-            redisUtil.set(key, portfolioUrl, 2592000);
-        } catch (Exception e) {
-            throw new TempSaveFailedException();
-        }
-    }
-
-    private String getPortfolioFromRedisOrDb(Long resumeId, Long memberId) {
-        String key = "resume:" + resumeId + ":portfolioUrl";
-        String url = (String) redisUtil.get(key);
-
-        if (url != null) {
-            return url;
-        }
-
-        Resume resume = resumeRepository.findById(resumeId)
-                .orElseThrow(ResumeNotFoundException::new);
-        String dbUrl = resume.getPortfolioUrl();
-        if (dbUrl != null) {
-            savePortfolioToRedis(resumeId, dbUrl, memberId); // Redis에 캐싱
-        }
-        return dbUrl;
-    }
-
-    private void updatePage3WithPreservedTimeSlots(Long resumeId, Long memberId) {
-        ResumeTempWrapper existing = resumeAnswerTempService.getTempSavedAnswers(resumeId, memberId);
-        ResumeReqDto oldPage3 = existing.getPage3();
-
-        ResumeReqDto updatedPage3 = new ResumeReqDto(
-                oldPage3 != null ? oldPage3.answers() : null,
-                oldPage3 != null ? oldPage3.timeSlots() : null,
-                null
-        );
-
-        resumeAnswerTempService.tempSaveAnswers(resumeId, 3, updatedPage3, memberId);
     }
 
     // Resume 조회 및 소유자 검증을 함께 수행하는 메서드


### PR DESCRIPTION
## ➕ 연관된 이슈
> #260 
> Close #260 

## 📑 작업 내용
> - 임시저장 API에서 `resumeId`와 로그인 사용자의 소유 여부 검증을 추가했습니다.
> - `ResumeAnswerTempService`에 `validateResumeOwnership()` 메서드 추가
>     - `resumeId`로 조회한 이력서가 현재 로그인한 사용자(`memberId`)의 것인지 검증  
>     - Resume가 존재하지 않으면 `ResumeNotFoundException`을,  사용자가 일치하지 않으면 `InvalidDataOwnerException`을 발생시켜 타인의 데이터를 조회하거나 저장하지 못하도록 방지
> - `resumeRepository.findById()`로 조회 후 소유자(`memberId`)가 다를 경우 `InvalidDataOwnerException` 발생하도록 하였습니다.
> - 해당 로직은 임시 저장(`tempSaveAnswers`) 및 임시 조회(`getTempSavedAnswers`) 모두에 적용됩니다.

> - 소셜 주소 저장/조회 시 사용자별 검증 로직을 강화했습니다.
> - 사용자 식별자(`memberId`)를 기반으로 데이터 접근을 제어하도록 하였습니다.
> - 다른 사용자의 `resumeId`로 소셜 주소 및 포트폴리오 저장 또는 조회 시 `InvalidDataOwnerException` 발생하도록 하였습니다.

<hr>

ResumeTempWrapper에 `memberId` 필드를 추가하고,
Redis 키는 `resumeId` 기반으로 단순화했습니다.

- 저장 시점: Redis에 저장되는 wrapper 내부에 `memberId`를 포함해 이후 접근 시 소유자 검증이 가능하도록 했습니다.
- 조회 시점: Redis에서 꺼낸 wrapper의 `memberId`가 현재 요청자와 일치하지 않으면 `InvalidDataOwnerException`을 발생시켜 데이터를 보호하도록 하였습니다.

이 구조를 통해 Redis 캐시가 의도치 않게 다른 사용자에게 노출되는 문제를 방지할 수 있습니다.
또한 Redis 키 자체는 단순해져 관리/조회가 쉬워졌습니다.

> 임시저장 로직에서 나올 수 있는 상황에 대해 엣지 케이스를 정리해보았습니다.

| 상황                                   | 대응 방식                                 |
|--------------------------------------|------------------------------------------|
| Redis 값이 아예 없거나 TTL 만료        | DB fallback 후 다시 캐싱                   |
| Redis 값은 존재하나, JSON 파싱 실패    | DB fallback 후 다시 캐싱                   |
| Redis 값은 정상이나, 내부 `memberId` 불일치 | `InvalidDataOwnerException` 발생 |
| DB에도 값이 없음 (`resumeId` 잘못된 경우) | `ResumeNotFoundException` 또는 `empty(memberId`) 반환 |
| page2 또는 page3가 null인 경우          | 각각 `ResumeReqDto.empty()`로 채워 NPE 방지 |
| Redis set 실패                        | 로깅만 하고 서비스 정상 동작 유지 |
| 사용자가 조작한 `resumeId` 요청 시       | `validateResumeOwnership()`에서 예외 발생 차단 |

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
