### PR TITLE
[Feat] ResumeTimeSlot과 Member를 함께 조회하는 쿼리 메서드 추가 및 DB fallback 로직에 적용

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -61,13 +61,6 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
             @Param("status") EvaluationStatus status
     );
 
-    @EntityGraph(attributePaths = {
-            "resumeQuestions",
-            "resumeTimeSlots",
-            "languageLevels"
-    })
-    List<Resume> findAllWithRelationsByIdIn(List<Long> resumeIds);
-
     @EntityGraph(attributePaths = {"resumeTimeSlots"})
     Optional<Resume> findWithTimeSlotsById(Long id);
 
@@ -77,4 +70,11 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
             "LEFT JOIN FETCH r.member " +
             "WHERE r.id IN :resumeIds")
     List<Resume> findAllByMemberIdWithTimeSlotsIn(@Param("resumeIds") List<Long> resumeIds);
+
+    @Query("SELECT DISTINCT r FROM Resume r " +
+            "LEFT JOIN FETCH r.resumeTimeSlots " +
+            "LEFT JOIN FETCH r.member " +
+            "WHERE r.id = :resumeId")
+    Optional<Resume> findByIdWithTimeSlotsAndMember(@Param("resumeId") Long resumeId);
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
@@ -193,7 +193,7 @@ public class ResumeAnswerTempService {
         if (wrapper.getPage2() != null) lastPage = 2;
         if (wrapper.getPage3() != null) lastPage = 3;
         wrapper.setLastPage(lastPage);
-
+        wrapper.setMemberId(memberId);
         return wrapper;
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeAnswerTempService.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ResumeAnswerTempService {
+
     private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
     private final ResumeRepository resumeRepository;
@@ -127,9 +128,10 @@ public class ResumeAnswerTempService {
         return wrapper;
     }
 
-
     private ResumeTempWrapper loadFromDatabase(Long resumeId, Long memberId) {
-        Resume resume = resumeRepository.findWithAllRelationsById(resumeId).orElse(null);
+        Resume resume = resumeRepository.findByIdWithTimeSlotsAndMember(resumeId)
+                .orElse(null);
+
         if (resume == null) {
             return null;
         }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #262 
> Close #262 

## 📑 작업 내용
> - `resumeTimeSlots`와 `member`를 fetch join으로 가져오는 `findByIdWithTimeSlotsAndMember` 메서드를 추가했습니다.
> - `ResumeAnswerTempService`의 DB fallback 로직(`loadFromDatabase`)에 해당 쿼리 메서드를 적용하여, 필요한 최소 fetch만 수행하도록 하였습니다.
> - Lazy 관계(`resumeQuestions`, `languageLevels`)는 @BatchSize 기반으로 지연 로딩하도록 설계하였습니다.

<hr>

> - Hibernate의 SQL 실행 통계(Session Metrics)를 확인해보았습니다.

```
2025-08-01 23:32:10 [http-nio-8080-exec-2] INFO  o.h.e.i.StatisticalLoggingSessionEventListener - Session Metrics {
    9210584 nanoseconds spent acquiring 1 JDBC connections;
    0 nanoseconds spent releasing 0 JDBC connections;
    62750 nanoseconds spent preparing 1 JDBC statements;
    10307458 nanoseconds spent executing 1 JDBC statements;
    0 nanoseconds spent executing 0 JDBC batches;
    0 nanoseconds spent performing 0 L2C puts;
    0 nanoseconds spent performing 0 L2C hits;
    0 nanoseconds spent performing 0 L2C misses;
    0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);
    0 nanoseconds spent executing 0 pre-partial-flushes;
    0 nanoseconds spent executing 0 partial-flushes (flushing a total of 0 entities and 0 collections)
} 
```
> 분석 결과
> - JDBC connection은 총 1건 획득 (acquiring 1 JDBC connections)
> - 실제 실행된 SQL 문은 1건 (executing 1 JDBC statements)
> - @BatchSize와 Lazy Loading 전략에 따라 필요한 연관 데이터(`resumeQuestions`, `languageLevels`)는 추후에 지연 로딩되며, 현재 시점에서는 SQL이 한 번만 실행
> - `findByIdWithTimeSlotsAndMember()` 쿼리를 통한 `resumeTimeSlots`, `member`만 fetch되고 나머지는 필요 시 개별 쿼리로 수행

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
