### PR TITLE
feat: 대시보드 업데이트 API 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
@@ -5,10 +5,12 @@ import com.tave.tavewebsite.domain.apply.dashboard.service.DashboardService;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.tave.tavewebsite.domain.apply.dashboard.controller.DashboardSuccessMessage.DASHBOARD_SUCCESS_MESSAGE;
+import static com.tave.tavewebsite.domain.apply.dashboard.controller.DashboardSuccessMessage.DASHBOARD_UPDATE_SUCCESS;
 
 @RestController
 @RequestMapping("/v1")
@@ -16,6 +18,14 @@ import static com.tave.tavewebsite.domain.apply.dashboard.controller.DashboardSu
 public class DashboardController {
 
     private final DashboardService dashboardService;
+
+    @PostMapping("/admin/dashboard")
+    public SuccessResponse updateDashboard() {
+
+        dashboardService.updateDetailedCounts();
+
+        return new SuccessResponse(DASHBOARD_UPDATE_SUCCESS.getMessage());
+    }
 
     @GetMapping("/admin/dashboard")
     public SuccessResponse<DashboardResDto> getDashboard() {

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardController.java
@@ -19,7 +19,7 @@ public class DashboardController {
 
     private final DashboardService dashboardService;
 
-    @PostMapping("/admin/dashboard")
+    @PostMapping("/manager/dashboard")
     public SuccessResponse updateDashboard() {
 
         dashboardService.updateDetailedCounts();
@@ -27,7 +27,7 @@ public class DashboardController {
         return new SuccessResponse(DASHBOARD_UPDATE_SUCCESS.getMessage());
     }
 
-    @GetMapping("/admin/dashboard")
+    @GetMapping("/manager/dashboard")
     public SuccessResponse<DashboardResDto> getDashboard() {
         return new SuccessResponse<>(dashboardService.getDashboard(), DASHBOARD_SUCCESS_MESSAGE.getMessage());
     }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardSuccessMessage.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/controller/DashboardSuccessMessage.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum DashboardSuccessMessage {
 
-    DASHBOARD_SUCCESS_MESSAGE("대시보드를 성공적으로 조회하였습니다.");
+    DASHBOARD_SUCCESS_MESSAGE("대시보드를 성공적으로 조회하였습니다."),
+    DASHBOARD_UPDATE_SUCCESS("대시보드를 성공적으로 업데이트하였습니다.");
 
     private final String message;
 }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardUpdateDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardUpdateDto.java
@@ -1,0 +1,15 @@
+package com.tave.tavewebsite.domain.apply.dashboard.dto;
+
+public record DashboardUpdateDto(
+        Long totalCount,
+        Long maleCount,
+        Long femaleCount,
+        Long backendCount,
+        Long webFrontCount,
+        Long designCount,
+        Long appFrontCount,
+        Long dataAnalysisCount,
+        Long deepCount
+
+) {
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/entity/Dashboard.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/entity/Dashboard.java
@@ -1,9 +1,6 @@
 package com.tave.tavewebsite.domain.apply.dashboard.entity;
 
-import com.tave.tavewebsite.domain.member.entity.Member;
-import com.tave.tavewebsite.domain.member.entity.Sex;
-import com.tave.tavewebsite.domain.resume.entity.Resume;
-import com.tave.tavewebsite.global.common.FieldType;
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardUpdateDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -69,28 +66,15 @@ public class Dashboard {
         this.deepCount = 0L;
     }
 
-    public void updateDashboard(Resume resume, Member member) {
-        this.totalCount += 1;
-        if(member.getSex().equals(Sex.MALE)) {
-            this.maleCount += 1;
-        } else this.femaleCount += 1;
-
-        if(resume.getField().equals(FieldType.APPFRONTEND)) {
-            this.appFrontCount += 1;
-        }
-        else if(resume.getField().equals(FieldType.WEBFRONTEND)) {
-            this.webFrontCount += 1;
-        }
-        else if(resume.getField().equals(FieldType.BACKEND)) {
-            this.backendCount += 1;
-        }
-        else if(resume.getField().equals(FieldType.DESIGN)) {
-            this.designCount += 1;
-        }
-        else if(resume.getField().equals(FieldType.DATAANALYSIS))
-            this.dataAnalysisCount += 1;
-        else if(resume.getField().equals(FieldType.DEEPLEARNING))
-            this.deepCount += 1;
-
+    public void updateDashboard(DashboardUpdateDto dto) {
+        this.totalCount = dto.totalCount();
+        this.maleCount = dto.maleCount();
+        this.femaleCount = dto.femaleCount();
+        this.backendCount = dto.backendCount();
+        this.webFrontCount = dto.webFrontCount();
+        this.designCount = dto.designCount();
+        this.appFrontCount = dto.appFrontCount();
+        this.dataAnalysisCount = dto.dataAnalysisCount();
+        this.deepCount = dto.deepCount();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardCustomRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardCustomRepository.java
@@ -1,0 +1,8 @@
+package com.tave.tavewebsite.domain.apply.dashboard.repository;
+
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardUpdateDto;
+
+public interface DashboardCustomRepository {
+
+    DashboardUpdateDto countEachElements();
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardCustomRepositoryImpl.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardCustomRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.tave.tavewebsite.domain.apply.dashboard.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardUpdateDto;
+import com.tave.tavewebsite.domain.member.entity.Sex;
+import com.tave.tavewebsite.global.common.FieldType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+
+import static com.tave.tavewebsite.domain.member.entity.QMember.member;
+import static com.tave.tavewebsite.domain.resume.entity.QResume.resume;
+
+@Repository
+@RequiredArgsConstructor
+public class DashboardCustomRepositoryImpl implements DashboardCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public DashboardUpdateDto countEachElements() {
+
+        DashboardUpdateDto dashboardUpdateDto = queryFactory
+                .select(
+                        Projections.constructor(
+                                DashboardUpdateDto.class,
+                                resume.count().coalesce(0L),
+                                // 성별
+                                new CaseBuilder().when(member.sex.eq(Sex.MALE)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(member.sex.eq(Sex.FEMALE)).then(1L).otherwise(0L).sum(),
+                                // 분야
+                                new CaseBuilder().when(resume.field.eq(FieldType.BACKEND)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(resume.field.eq(FieldType.WEBFRONTEND)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(resume.field.eq(FieldType.DESIGN)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(resume.field.eq(FieldType.APPFRONTEND)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(resume.field.eq(FieldType.DATAANALYSIS)).then(1L).otherwise(0L).sum(),
+                                new CaseBuilder().when(resume.field.eq(FieldType.DEEPLEARNING)).then(1L).otherwise(0L).sum()
+                        )).from(resume)
+                .leftJoin(member)
+                .on(
+                        member.id.eq(resume.member.id)
+                ).fetchOne();
+
+        // null 반환 방지: 모두 0으로 채운 DTO
+        return Objects.requireNonNullElseGet(dashboardUpdateDto, () ->
+                new DashboardUpdateDto(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L));
+
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/repository/DashboardRepository.java
@@ -3,5 +3,5 @@ package com.tave.tavewebsite.domain.apply.dashboard.repository;
 import com.tave.tavewebsite.domain.apply.dashboard.entity.Dashboard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DashboardRepository extends JpaRepository<Dashboard, Long> {
+public interface DashboardRepository extends JpaRepository<Dashboard, Long>, DashboardCustomRepository {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/PersonalInfoService.java
@@ -4,7 +4,6 @@ import com.tave.tavewebsite.domain.applicant.history.entity.ApplicantHistory;
 import com.tave.tavewebsite.domain.applicant.history.entity.ApplicationStatus;
 import com.tave.tavewebsite.domain.applicant.history.repository.ApplicantHistoryRepository;
 import com.tave.tavewebsite.domain.applicant.history.service.ApplicantHistoryService;
-import com.tave.tavewebsite.domain.apply.dashboard.service.DashboardService;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.member.memberRepository.MemberRepository;
 import com.tave.tavewebsite.domain.programinglaunguage.entity.LanguageLevel;
@@ -52,7 +51,6 @@ public class PersonalInfoService {
     private final ApplicantHistoryRepository applicantHistoryRepository;
     private final ApplicantHistoryService applicantHistoryService;
     private final ResumeQuestionRepository resumeQuestionRepository;
-    private final DashboardService dashboardService;
 
     private final RedisUtil redisUtil;
 
@@ -201,7 +199,6 @@ public class PersonalInfoService {
         Resume resume = getResumeEntityById(resumeId);
         resume.submit();
         resumeRepository.save(resume);
-        dashboardService.addDetailedCount(resume, resume.getMember());
     }
 
     public List<TimeSlotResDto> getInterviewTime() {


### PR DESCRIPTION
## ➕ 연관된 이슈
> #264 
> Close #264 

## 📑 작업 내용
> - API 호출을 통해 이력서의 업데이트 사항을 대시보드에 반영하였습니다.
(테스트 완료)

## ✂️ 스크린샷 (선택)
현재 이력서가 한 개 존재하는 상태에서 조회를 하였더니 성공적으로 대시보드에 반영된 것을 확인할 수 있었습니다.
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/6797bf4c-3ff7-4553-99e5-9da07b8a07ce" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
