### PR TITLE
[fix] 포트폴리오 업로드 시 null 값 허용

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/SocialLinksController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/SocialLinksController.java
@@ -45,14 +45,9 @@ public class SocialLinksController {
     // 포트폴리오 업로드
     @PostMapping("/portfolio")
     public SuccessResponse updatePortfolio(@PathVariable("resumeId") Long resumeId,
-                                           @RequestParam("file") MultipartFile file) {
+                                           @RequestParam(value = "file", required = false) MultipartFile file) {
         Long memberId = SecurityUtils.getCurrentMember().getId();
-
-        fileValidator.validateSize(file);
-        URL portfolioUrl = s3Service.uploadFile(file);
-
-        socialLinksService.updatePortfolio(resumeId, portfolioUrl.toString(), memberId);
-        PortfolioUploadResponseDto responseDto = new PortfolioUploadResponseDto(portfolioUrl.toString());
+        PortfolioUploadResponseDto responseDto = socialLinksService.updatePortfolio(resumeId, file, memberId);
         return new SuccessResponse<>(responseDto, SocialLinksSuccessMessage.UPLOAD_SUCCESS.getMessage());
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -238,7 +238,7 @@ public class ResumeQuestionService {
     @Transactional(readOnly = true)
     public ResumeDetailResponse getResumeDetail(Long resumeId) {
         Resume resume = resumeRepository.findWithTimeSlotsById(resumeId)
-                .orElseThrow(() -> new ResumeNotFoundException());
+                .orElseThrow(ResumeNotFoundException::new);
 
         List<DetailResumeQuestionResponse> commonQuestions = new ArrayList<>();
         List<DetailResumeQuestionResponse> specificQuestions = new ArrayList<>();
@@ -266,7 +266,7 @@ public class ResumeQuestionService {
                 .sorted(Comparator.comparing(DetailResumeQuestionResponse::ordered))
                 .toList();
 
-        return ResumeDetailResponse.of(resume, commonQuestions, specificQuestions, languageLevels);
+        return ResumeDetailResponse.of(resume, commonDtoList, specificDtoList, languageLevels);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeQuestionService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -55,7 +56,10 @@ public class ResumeQuestionService {
 
     // 분야 별 ResumeQuestion 조회하기
     public List<DetailResumeQuestionResponse> getResumeQuestionList(Resume resume, FieldType fieldType) {
-        List<ResumeQuestion> resumeQuestionList = findResumeQuestionsByResumeId(resume, fieldType);
+        List<ResumeQuestion> resumeQuestionList = findResumeQuestionsByResumeId(resume, fieldType)
+                .stream()
+                .sorted(Comparator.comparing(ResumeQuestion::getOrdered))
+                .toList();
 
         return mapResumeQuestionListToDetailResponse(resumeQuestionList);
     }
@@ -250,6 +254,16 @@ public class ResumeQuestionService {
 
         List<LanguageLevelResponseDto> languageLevels = resume.getProgramingLanguages().stream()
                 .map(LanguageLevelResponseDto::fromEntity)
+                .toList();
+
+        List<DetailResumeQuestionResponse> commonDtoList = commonQuestions
+                .stream()
+                .sorted(Comparator.comparing(DetailResumeQuestionResponse::ordered))
+                .toList();
+
+        List<DetailResumeQuestionResponse> specificDtoList = specificQuestions
+                .stream()
+                .sorted(Comparator.comparing(DetailResumeQuestionResponse::ordered))
                 .toList();
 
         return ResumeDetailResponse.of(resume, commonQuestions, specificQuestions, languageLevels);

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/SocialLinksService.java
@@ -1,21 +1,31 @@
 package com.tave.tavewebsite.domain.resume.service;
 
 import com.tave.tavewebsite.domain.resume.dto.request.SocialLinksRequestDto;
+import com.tave.tavewebsite.domain.resume.dto.response.PortfolioUploadResponseDto;
 import com.tave.tavewebsite.domain.resume.dto.response.SocialLinksResponseDto;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.exception.InvalidDataOwnerException;
 import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
+import com.tave.tavewebsite.domain.resume.validator.FileValidator;
+import com.tave.tavewebsite.global.s3.service.S3Service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URL;
 
 @Service
 public class SocialLinksService {
 
     private final ResumeRepository resumeRepository;
+    private final S3Service s3Service;
+    private final FileValidator fileValidator;
 
-    public SocialLinksService(ResumeRepository resumeRepository) {
+    public SocialLinksService(ResumeRepository resumeRepository, S3Service s3Service, FileValidator fileValidator) {
         this.resumeRepository = resumeRepository;
+        this.s3Service = s3Service;
+        this.fileValidator = fileValidator;
     }
 
     // 소셜 주소 등록
@@ -42,10 +52,31 @@ public class SocialLinksService {
         resume.updateSocialLinks(dto);
     }
 
-    public void updatePortfolio(Long resumeId, String portfolioUrl, Long memberId) {
+    @Transactional
+    public PortfolioUploadResponseDto updatePortfolio(Long resumeId, MultipartFile file, Long memberId) {
         Resume resume = getAuthorizedResume(resumeId, memberId);
-        resume.updatePortfolio(portfolioUrl);
+
+        String existingUrl = resume.getPortfolioUrl();
+
+        // 기존 파일 삭제
+        if (existingUrl != null && !existingUrl.isEmpty()) {
+            s3Service.deleteFileByUrl(existingUrl);
+        }
+
+        if (file == null) {
+            // null 업로드 처리 (삭제)
+            resume.updatePortfolio(null);
+            resumeRepository.save(resume);
+            return new PortfolioUploadResponseDto(null);
+        }
+
+        // 파일 크기 & 확장자 검증
+        fileValidator.validateSize(file);
+        URL portfolioUrl = s3Service.uploadFile(file);
+
+        resume.updatePortfolio(portfolioUrl.toString());
         resumeRepository.save(resume);
+        return new PortfolioUploadResponseDto(portfolioUrl.toString());
     }
 
     // Resume 조회 및 소유자 검증을 함께 수행하는 메서드

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3Service.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 
@@ -267,6 +268,24 @@ public class S3Service {
     private void checkIsXLSXFile(MultipartFile file) {
         if (!XLSX_APPLICATION_TYPE.equals(file.getContentType())) {
             throw new IsNotXlsxFileException();
+        }
+    }
+
+    public void deleteFileByUrl(String fileUrl) {
+        try {
+            String key = extractKeyFromUrl(fileUrl);
+            s3Client.deleteObject(bucketName, key);
+        } catch (Exception e) {
+            throw new S3NotExistNameException();
+        }
+    }
+
+    private String extractKeyFromUrl(String fileUrl) {
+        try {
+            URL url = new URL(fileUrl);
+            return url.getPath().substring(1); // 앞의 '/' 제거
+        } catch (MalformedURLException e) {
+            throw new S3NotExistNameException();
         }
     }
 


### PR DESCRIPTION
## ➕ 연관된 이슈
> #268 
> Close #268 

## 📑 작업 내용
> - 기존 로직은 사용자가 포트폴리오 파일을 업로드한 이후 삭제할 수 없는 문제가 있었습니다.
> - 업로드된 포트폴리오를 null로 업데이트(삭제) 할 수 있도록 수정하였습니다.

`extractKeyFromUrl()`

<img width="1126" height="336" alt="image" src="https://github.com/user-attachments/assets/87b235a0-0475-43ee-b010-ba714798f181" />

> - S3 URL에서 파일 key를 추출하기 위한 메서드
> - 파일 삭제 시 S3에서 해당 객체를 정확히 찾아 삭제하기 위해 사용됩니다.

`updatePortfolio()` 메서드 개선

<img width="1584" height="1088" alt="image" src="https://github.com/user-attachments/assets/bb1d985e-c9b9-4d3c-9d9e-d334ebe1de71" />

> - 새 파일이 들어오지 않은 경우(null), 기존 포트폴리오 URL이 있다면 S3에서 파일 삭제 후 `resume`의 포트폴리오 필드를 null로 업데이트합니다.
> - 새 파일이 들어온 경우엔 기존 파일 삭제 후 새 파일 업로드 및 URL을 갱신합니다.

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
