### PR TITLE
[HOTFIX] 포트폴리오 다운로드 구현

### DIFF
--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewExcelController.java
@@ -1,6 +1,6 @@
 package com.tave.tavewebsite.domain.interviewfinal.controller;
 
-import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.usecase.InterviewExcelUseCase;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +30,7 @@ public class InterviewExcelController {
 
     @GetMapping("/excel/interviewer/time-table")
     public ResponseEntity<InputStreamResource> downloadPossibleTimeTableExcel() throws IOException {
-        S3ExcelFileInputStreamDto dto = useCase.getPossibleInterviewTimeCSV();
+        S3FileInputStreamDto dto = useCase.getPossibleInterviewTimeCSV();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())
@@ -52,7 +52,7 @@ public class InterviewExcelController {
     // 면접관 전용 시간표 파일 다운로드
     @GetMapping("/excel/interview/time-table")
     public ResponseEntity<InputStreamResource> downloadInterviewTimeTableForManager() throws IOException {
-        S3ExcelFileInputStreamDto dto = useCase.getInterviewTimeTableForManagerXLSX();
+        S3FileInputStreamDto dto = useCase.getInterviewTimeTableForManagerXLSX();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())
@@ -63,7 +63,7 @@ public class InterviewExcelController {
     // 면접 평가 초기 양식 다운로드
     @GetMapping("/excel/interview/evaluation-form")
     public ResponseEntity<InputStreamResource> downloadInterviewEvaluationInitialForm() throws IOException {
-        S3ExcelFileInputStreamDto dto = useCase.getInterviewEvaluationInitialFormXLSX();
+        S3FileInputStreamDto dto = useCase.getInterviewEvaluationInitialFormXLSX();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())
@@ -74,7 +74,7 @@ public class InterviewExcelController {
     // 면접 평가 시트 다운로드
     @GetMapping("/excel/interview/evaluation")
     public ResponseEntity<InputStreamResource> downloadInterviewEvaluation() throws IOException {
-        S3ExcelFileInputStreamDto dto = useCase.getInterviewEvaluationXLSX();
+        S3FileInputStreamDto dto = useCase.getInterviewEvaluationXLSX();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/controller/InterviewFinalController.java
@@ -1,7 +1,6 @@
 package com.tave.tavewebsite.domain.interviewfinal.controller;
 
-import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
-import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalDetailDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalEvaluateResDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalForMemberDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.InterviewFinalPageDto;
@@ -33,7 +32,7 @@ public class InterviewFinalController {
     @GetMapping("/v1/manager/interview-final/form")
     public ResponseEntity<InputStreamResource> interviewFinalForm() throws IOException {
 
-        S3ExcelFileInputStreamDto dto = interviewFinalUseCase.downloadInterviewFinal();
+        S3FileInputStreamDto dto = interviewFinalUseCase.downloadInterviewFinal();
 
         return ResponseEntity.ok()
                 .headers(dto.headers())

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/S3FileInputStreamDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/S3FileInputStreamDto.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpHeaders;
 import java.io.IOException;
 
 @Builder
-public record S3ExcelFileInputStreamDto(
+public record S3FileInputStreamDto(
         InputStreamResource inputStreamResource,
         HttpHeaders headers,
         long contentLength
 ) {
-    public static S3ExcelFileInputStreamDto from(S3ObjectInputStream s3ObjectInputStream, HttpHeaders headers, long contentLength) throws IOException {
-        return S3ExcelFileInputStreamDto.builder()
+    public static S3FileInputStreamDto from(S3ObjectInputStream s3ObjectInputStream, HttpHeaders headers, long contentLength) throws IOException {
+        return S3FileInputStreamDto.builder()
                 .inputStreamResource(new InputStreamResource(s3ObjectInputStream))
                 .headers(headers)
                 .contentLength(contentLength)

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewExcelUseCase.java
@@ -1,7 +1,7 @@
 package com.tave.tavewebsite.domain.interviewfinal.usecase;
 
 import com.tave.tavewebsite.domain.apply.initial.setup.service.ApplyInitialSetupService;
-import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewExcelService;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
@@ -65,7 +65,7 @@ public class InterviewExcelUseCase {
 
     }
 
-    public S3ExcelFileInputStreamDto getPossibleInterviewTimeCSV() throws IOException {
+    public S3FileInputStreamDto getPossibleInterviewTimeCSV() throws IOException {
         return s3DownloadSerivce.downloadPossibleTimeTableXlsx();
     }
 
@@ -73,15 +73,15 @@ public class InterviewExcelUseCase {
         s3Service.uploadTimeTableForMangerXLSXToS3(file);
     }
 
-    public S3ExcelFileInputStreamDto getInterviewTimeTableForManagerXLSX() throws IOException {
+    public S3FileInputStreamDto getInterviewTimeTableForManagerXLSX() throws IOException {
         return s3DownloadSerivce.downloadInterviewTimeTableForManagerXLSX();
     }
 
-    public S3ExcelFileInputStreamDto getInterviewEvaluationInitialFormXLSX() throws IOException {
+    public S3FileInputStreamDto getInterviewEvaluationInitialFormXLSX() throws IOException {
         return s3DownloadSerivce.downloadInterviewEvaluationInitialFormXLSX();
     }
 
-    public S3ExcelFileInputStreamDto getInterviewEvaluationXLSX() throws IOException {
+    public S3FileInputStreamDto getInterviewEvaluationXLSX() throws IOException {
         return s3DownloadSerivce.downloadInterviewEvaluationXLSX();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -2,7 +2,7 @@ package com.tave.tavewebsite.domain.interviewfinal.usecase;
 
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
-import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.*;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.InterviewTimeTableDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.response.timetable.InterviewTimeTableGroupByDayDto;
@@ -58,7 +58,7 @@ public class InterviewFinalUseCase {
     private final InterviewFinalRepository interviewFinalRepository;
     private final ResumeRepository resumeRepository;
 
-    public S3ExcelFileInputStreamDto downloadInterviewFinal() throws IOException {
+    public S3FileInputStreamDto downloadInterviewFinal() throws IOException {
         return s3DownloadSerivce.downloadInterviewFinalSetUpForm();
     }
 

--- a/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeController.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/controller/ResumeController.java
@@ -1,14 +1,19 @@
 package com.tave.tavewebsite.domain.resume.controller;
 
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeListResponse;
 import com.tave.tavewebsite.domain.resume.usecase.ResumeUseCase;
 import com.tave.tavewebsite.global.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -35,4 +40,18 @@ public class ResumeController {
 
         return new SuccessResponse(response, RESUME_GET_TO_DATE_AND_TIME_SUCCESS.getMessage());
     }
+
+    @GetMapping("/v1/manager/resume/portfolio/{resumeId}")
+    public ResponseEntity<InputStreamResource> downloadPortfolio(
+            @PathVariable("resumeId") Long resumeId
+    ) throws IOException {
+
+        S3FileInputStreamDto response = resumeUseCase.downloadPortfolio(resumeId);
+
+        return ResponseEntity.ok()
+                .headers(response.headers())
+                .contentLength(response.contentLength())
+                .body(response.inputStreamResource());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumePortfolioDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumePortfolioDto.java
@@ -1,0 +1,17 @@
+package com.tave.tavewebsite.domain.resume.dto.response;
+
+import com.tave.tavewebsite.domain.resume.entity.Resume;
+import lombok.Builder;
+
+@Builder
+public record ResumePortfolioDto(
+        String portfolioUrl,
+        String memberName
+) {
+    public static ResumePortfolioDto of(Resume resume) {
+        return ResumePortfolioDto.builder()
+                .portfolioUrl(resume.getPortfolioUrl())
+                .memberName(resume.getMember().getUsername())
+                .build();
+    }
+}

--- a/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/repository/ResumeRepository.java
@@ -79,4 +79,9 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeCus
     Optional<Resume> findByIdWithTimeSlotsAndMember(@Param("resumeId") Long resumeId);
 
     long countByState(ResumeState state);
+
+    @Query("SELECT r FROM Resume r " +
+            "JOIN FETCH r.member " +
+            "WHERE r.id = :resumeId ")
+    Optional<Resume> findResumeWithMemberByResumeId(Long resumeId);
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeGetService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeGetService.java
@@ -1,10 +1,13 @@
 package com.tave.tavewebsite.domain.resume.service;
 
+import com.tave.tavewebsite.domain.member.dto.response.MemberResumeDto;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeMemberInfoDto;
+import com.tave.tavewebsite.domain.resume.dto.response.ResumePortfolioDto;
 import com.tave.tavewebsite.domain.resume.entity.EvaluationStatus;
 import com.tave.tavewebsite.domain.resume.entity.Resume;
 import com.tave.tavewebsite.domain.resume.entity.ResumeTimeSlot;
+import com.tave.tavewebsite.domain.resume.exception.ResumeNotFoundException;
 import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import jakarta.persistence.Tuple;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +55,20 @@ public class ResumeGetService {
     public List<Tuple> getResumeListByGenerationAnd(String generation, EvaluationStatus status) {
         return resumeRepository
                 .findResumesWithInterviewTimesAndMemberByGenerationAndStatus(generation, status);
+    }
+
+    public ResumePortfolioDto getResumeWithMemberByResumeId(Long resumeId) {
+        Resume resume = getResumeWithMember(resumeId);
+        return ResumePortfolioDto.of(resume);
+    }
+
+    /*
+    * refactoring
+    * */
+
+    public Resume getResumeWithMember(Long resumeId) {
+        return resumeRepository.findResumeWithMemberByResumeId(resumeId)
+                .orElseThrow(ResumeNotFoundException::new);
     }
 
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/usecase/ResumeUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/usecase/ResumeUseCase.java
@@ -1,13 +1,17 @@
 package com.tave.tavewebsite.domain.resume.usecase;
 
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import com.tave.tavewebsite.domain.interviewfinal.entity.InterviewFinal;
 import com.tave.tavewebsite.domain.interviewfinal.service.InterviewGetService;
 import com.tave.tavewebsite.domain.resume.dto.response.ResumeListResponse;
+import com.tave.tavewebsite.domain.resume.dto.response.ResumePortfolioDto;
+import com.tave.tavewebsite.domain.resume.service.ResumeGetService;
 import com.tave.tavewebsite.domain.resume.service.ResumeQuestionService;
+import com.tave.tavewebsite.global.s3.service.S3DownloadSerivce;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -18,6 +22,8 @@ public class ResumeUseCase {
 
     private final ResumeQuestionService resumeQuestionService;
     private final InterviewGetService interviewGetService;
+    private final ResumeGetService resumeGetService;
+    private final S3DownloadSerivce s3DownloadSerivce;
 
     public ResumeListResponse getResumeByInterviewDateTime(LocalDate date, LocalTime time) {
         // 면접 날짜 + 시간에 있는 지원자의 ResumeIdList 가져오기
@@ -28,4 +34,10 @@ public class ResumeUseCase {
 
         return resumeQuestionService.getResumeListDetails(resumeIdList);
     }
+
+    public S3FileInputStreamDto downloadPortfolio(Long resumeId) throws IOException {
+        ResumePortfolioDto dto = resumeGetService.getResumeWithMemberByResumeId(resumeId);
+        return s3DownloadSerivce.downloadPortfolioPDF(dto.portfolioUrl(), dto.memberName());
+    }
+
 }

--- a/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
+++ b/src/main/java/com/tave/tavewebsite/global/s3/service/S3DownloadSerivce.java
@@ -2,7 +2,7 @@ package com.tave.tavewebsite.global.s3.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
-import com.tave.tavewebsite.domain.interviewfinal.dto.S3ExcelFileInputStreamDto;
+import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
@@ -47,51 +47,62 @@ public class S3DownloadSerivce {
     }
 
     // 최종면접 설정 양식 다운로드
-    public S3ExcelFileInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
+    public S3FileInputStreamDto downloadInterviewFinalSetUpForm() throws IOException {
             S3Object s3Object = s3Client.getObject(bucketName, finalInterviewBasicFormUrl);
             HttpHeaders headers = createHttpHeaders(FINAL_INTERVIEW_FORM_NAME);
 
-            return S3ExcelFileInputStreamDto.from(
+            return S3FileInputStreamDto.from(
                     s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
             );
     }
 
     // 서류합격자들 면접 가능 시간 파악 엑셀
-    public S3ExcelFileInputStreamDto downloadPossibleTimeTableXlsx() throws IOException {
+    public S3FileInputStreamDto downloadPossibleTimeTableXlsx() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewPossibleTimeTable);
         HttpHeaders headers = createHttpHeaders(POSSIBLE_TIME_TABLE_FORM_NAME);
 
-        return S3ExcelFileInputStreamDto.from(
+        return S3FileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
         );
     }
 
     // 면접 시간표 다운로드 (관리자용)
-    public S3ExcelFileInputStreamDto downloadInterviewTimeTableForManagerXLSX() throws IOException {
+    public S3FileInputStreamDto downloadInterviewTimeTableForManagerXLSX() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewTimeTableForManager);
         HttpHeaders headers = createHttpHeaders(INTERVIEW_TIME_TABLE_FOR_MANAGER_FILE_NAME);
 
-        return S3ExcelFileInputStreamDto.from(
+        return S3FileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
         );
     }
 
     // 면접 평가 초기 양식 다운로드
-    public S3ExcelFileInputStreamDto downloadInterviewEvaluationInitialFormXLSX() throws IOException {
+    public S3FileInputStreamDto downloadInterviewEvaluationInitialFormXLSX() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewEvaluationInitialForm);
         HttpHeaders headers = createHttpHeaders(INTERVIEW_EVALUATION_INITIAL_FORM_NAME);
 
-        return S3ExcelFileInputStreamDto.from(
+        return S3FileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
         );
     }
 
     // 면접 평가 시트 다운로드 (질문 + 면접자 정보)
-    public S3ExcelFileInputStreamDto downloadInterviewEvaluationXLSX() throws IOException {
+    public S3FileInputStreamDto downloadInterviewEvaluationXLSX() throws IOException {
         S3Object s3Object = s3Client.getObject(bucketName, interviewEvaluationXLSX);
         HttpHeaders headers = createHttpHeaders(INTERVIEW_EVALUATION_XLSX_NAME);
 
-        return S3ExcelFileInputStreamDto.from(
+        return S3FileInputStreamDto.from(
+                s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
+        );
+    }
+
+    public S3FileInputStreamDto downloadPortfolioPDF(String portfolioUrl, String memberName) throws IOException {
+        String fileName = extractFilename(portfolioUrl);
+        S3Object s3Object = s3Client.getObject(bucketName, fileName);
+
+        HttpHeaders headers = createHttpHeaders(memberName + " Portfolio.pdf");
+
+        return S3FileInputStreamDto.from(
                 s3Object.getObjectContent(), headers, s3Object.getObjectMetadata().getContentLength()
         );
     }
@@ -110,5 +121,12 @@ public class S3DownloadSerivce {
         headers.setContentDisposition(contentDisposition);
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE);
         return headers;
+    }
+
+    private String extractFilename(String fileUrl) {
+        if (fileUrl.contains("/")) {
+            return fileUrl.substring(fileUrl.lastIndexOf('/') + 1);
+        }
+        return fileUrl;
     }
 }


### PR DESCRIPTION
## ➕ 연관된 이슈
> #274
> Close #274

## 📑 작업 내용
> - 포트폴리오 다운로드 API 구현

프론트측에서 포트폴리오 다운로드 구현이 힘들어 백엔드에서 구현합니다.


## ✂️ 스크린샷 (선택)
>

### 구현 스크린샷

<img width="500" height="190" alt="image" src="https://github.com/user-attachments/assets/196dac62-2dce-4c2c-a103-03d0f4b0c5f6" />


## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
