### PR TITLE
[Fix] eclipse-temurin:17-jdk 이미지를 사용하도록 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,8 @@
 # Dockerfile
+FROM eclipse-temurin:17-jdk
 
-# jdk17 Image Start
-FROM openjdk:17
-
-# 인자 설정 - JAR_File
 ARG JAR_FILE=build/libs/*.jar
 
-# jar 파일 복제
 COPY ${JAR_FILE} app.jar
 
-# 인자 설정 부분과 jar 파일 복제 부분 합쳐서 진행해도 무방
-#COPY build/libs/*.jar app.jar
-
-# 실행 명령어
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## ➕ 연관된 이슈
> #286 
> Close #286 

## 📑 작업 내용
> - eclipse-temurin:17-jdk 이미지를 사용하도록 변경

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
