### PR TITLE
[Feat] 특정 API에 기수 정보 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ dependencies {
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
-    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     // redis shedlock
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     // cache
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     // redis shedlock
     implementation 'net.javacrumbs.shedlock:shedlock-spring:5.16.0'

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/dto/DashboardResDto.java
@@ -7,6 +7,7 @@ public record DashboardResDto(
         double comparisonRatio,
         long temperCount,
         List<DashboardRatioResDto> sexRatioDtos,
-        List<DashboardRatioResDto> fieldRatioDtos
+        List<DashboardRatioResDto> fieldRatioDtos,
+        String generation
 ) {
 }

--- a/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/service/DashboardService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/dashboard/service/DashboardService.java
@@ -6,6 +6,7 @@ import com.tave.tavewebsite.domain.apply.dashboard.dto.DashboardUpdateDto;
 import com.tave.tavewebsite.domain.apply.dashboard.entity.Dashboard;
 import com.tave.tavewebsite.domain.apply.dashboard.exception.DashboardErrorException;
 import com.tave.tavewebsite.domain.apply.dashboard.repository.DashboardRepository;
+import com.tave.tavewebsite.domain.apply.initial.setup.service.ApplyInitialSetUpGetService;
 import com.tave.tavewebsite.global.redis.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import java.util.List;
 public class DashboardService {
 
     private final DashboardRepository dashboardRepository;
+    private final ApplyInitialSetUpGetService applyInitialSetUpGetService;
     private final RedisUtil redisUtil;
 
     public DashboardResDto getDashboard() {
@@ -31,9 +33,10 @@ public class DashboardService {
         Long totalCount = dashboard.getTotalCount();
         List<DashboardRatioResDto> dashboardRatioResDtosBySex = extractedSexDto(totalCount, dashboard);
         List<DashboardRatioResDto> dashboardRatioResDtosByField = extractedFieldDto(totalCount, dashboard);
+        String currentGeneration = applyInitialSetUpGetService.getCurrentGeneration();
 
         return new DashboardResDto(totalCount, generationRatio, tempCount,
-                dashboardRatioResDtosBySex, dashboardRatioResDtosByField);
+                dashboardRatioResDtosBySex, dashboardRatioResDtosByField, currentGeneration);
     }
 
     // 지원 초기 설정 시 대시보드도 초기화

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetUpGetService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetUpGetService.java
@@ -3,6 +3,7 @@ package com.tave.tavewebsite.domain.apply.initial.setup.service;
 import com.tave.tavewebsite.domain.apply.initial.setup.exception.ApplyInitialSetupException.ApplyInitialSetupNotFoundException;
 import com.tave.tavewebsite.domain.apply.initial.setup.repository.ApplyInitialSetupRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,6 +12,7 @@ public class ApplyInitialSetUpGetService {
 
     private final ApplyInitialSetupRepository applyInitialSetupRepository;
 
+    @Cacheable(value = "applySetupCache", key = "'generation'")
     public String getCurrentGeneration() {
         return applyInitialSetupRepository.findById(1L)
                 .orElseThrow(ApplyInitialSetupNotFoundException::new)

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetUpGetService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetUpGetService.java
@@ -1,0 +1,20 @@
+package com.tave.tavewebsite.domain.apply.initial.setup.service;
+
+import com.tave.tavewebsite.domain.apply.initial.setup.exception.ApplyInitialSetupException.ApplyInitialSetupNotFoundException;
+import com.tave.tavewebsite.domain.apply.initial.setup.repository.ApplyInitialSetupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyInitialSetUpGetService {
+
+    private final ApplyInitialSetupRepository applyInitialSetupRepository;
+
+    public String getCurrentGeneration() {
+        return applyInitialSetupRepository.findById(1L)
+                .orElseThrow(ApplyInitialSetupNotFoundException::new)
+                .getGeneration();
+    }
+
+}

--- a/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/apply/initial/setup/service/ApplyInitialSetupService.java
@@ -13,6 +13,7 @@ import com.tave.tavewebsite.domain.resume.repository.ResumeRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,6 +61,7 @@ public class ApplyInitialSetupService {
         applyInitialSetupRepository.save(entity);
     }
 
+    @CacheEvict(value = "applySetupCache", key = "'generation'")
     public void updateInitialSetup(ApplyInitialSetupRequestDto dto) {
         ApplyInitialSetup existing = applyInitialSetupRepository.findById(1L)
                 .orElseThrow(ApplyInitialSetupNotFoundException::new);

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/response/timetable/InterviewTimeTableDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/dto/response/timetable/InterviewTimeTableDto.java
@@ -9,12 +9,14 @@ import java.util.List;
 public record InterviewTimeTableDto(
 
         TotalDateTimeDto totalDateTimeDto,
-        List<InterviewTimeTableGroupByDayDto> timetableList
+        List<InterviewTimeTableGroupByDayDto> timetableList,
+        String generation
 ) {
-    public static InterviewTimeTableDto of(TotalDateTimeDto totalDateTimeDto, List<InterviewTimeTableGroupByDayDto> timetableList) {
+    public static InterviewTimeTableDto of(TotalDateTimeDto totalDateTimeDto, List<InterviewTimeTableGroupByDayDto> timetableList, String generation) {
         return InterviewTimeTableDto.builder()
                 .totalDateTimeDto(totalDateTimeDto)
                 .timetableList(timetableList)
+                .generation(generation)
                 .build();
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
+++ b/src/main/java/com/tave/tavewebsite/domain/interviewfinal/usecase/InterviewFinalUseCase.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.interviewfinal.usecase;
 
+import com.tave.tavewebsite.domain.apply.initial.setup.service.ApplyInitialSetUpGetService;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalConvertDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.InterviewFinalSaveDto;
 import com.tave.tavewebsite.domain.interviewfinal.dto.S3FileInputStreamDto;
@@ -51,6 +52,7 @@ public class InterviewFinalUseCase {
     private final InterviewGetService interviewGetService;
     private final InterviewDeleteService interviewDeleteService;
     private final InterviewFinalTestService interviewTestService; // todo 베타 테스트 용 로직.
+    private final ApplyInitialSetUpGetService applyInitialSetUpGetService;
     private final S3DownloadSerivce s3DownloadSerivce;
     private final InterviewPlaceService interviewPlaceService;
     private final InterviewFinalMapper mapper;
@@ -120,7 +122,8 @@ public class InterviewFinalUseCase {
         List<InterviewTimeTableGroupByDayDto> timeTableList = groupUtil.createTimeTableDtoList(group);
         TotalDateTimeDto totalDateTimeList = groupUtil.getTotalDateTimeDto(group);
 
-        return InterviewTimeTableDto.of(totalDateTimeList, timeTableList);
+        String currentGeneration = applyInitialSetUpGetService.getCurrentGeneration();
+        return InterviewTimeTableDto.of(totalDateTimeList, timeTableList, currentGeneration);
     }
 
     // todo 베타 테스트용 기능이므로 추 후 삭제할 것.

--- a/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeEvaluateResDto.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/dto/response/ResumeEvaluateResDto.java
@@ -6,17 +6,22 @@ public record ResumeEvaluateResDto(
         long totalRecruiter,
         long notCompletedRecruiter,
         long completedRecruiter,
-        Page<ResumeResDto> resumeResDtos
+        Page<ResumeResDto> resumeResDtos,
+        String generation
 ) {
-    public static ResumeEvaluateResDto fromResume(long totalRecruiter,
-                                                  long notCompletedRecruiter,
-                                                  long completedRecruiter,
-                                                  Page<ResumeResDto> resumeResDtos) {
+    public static ResumeEvaluateResDto fromResume(
+            long totalRecruiter,
+            long notCompletedRecruiter,
+            long completedRecruiter,
+            Page<ResumeResDto> resumeResDtos,
+            String generation
+                                                  ) {
         return new ResumeEvaluateResDto(
                 totalRecruiter,
                 notCompletedRecruiter,
                 completedRecruiter,
-                resumeResDtos
+                resumeResDtos,
+                generation
         );
     }
 }

--- a/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeEvaluateService.java
+++ b/src/main/java/com/tave/tavewebsite/domain/resume/service/ResumeEvaluateService.java
@@ -1,5 +1,6 @@
 package com.tave.tavewebsite.domain.resume.service;
 
+import com.tave.tavewebsite.domain.apply.initial.setup.service.ApplyInitialSetUpGetService;
 import com.tave.tavewebsite.domain.member.entity.Member;
 import com.tave.tavewebsite.domain.resume.dto.request.DocumentEvaluationReqDto;
 import com.tave.tavewebsite.domain.resume.dto.request.FinalDocumentEvaluationReqDto;
@@ -28,6 +29,7 @@ import java.util.List;
 public class ResumeEvaluateService {
 
     private final ResumeEvaluationRepository resumeEvaluationRepository;
+    private final ApplyInitialSetUpGetService applyInitialSetUpGetService;
     private final ResumeRepository resumeRepository;
 
     public Member getCurrentMember() {
@@ -61,12 +63,15 @@ public class ResumeEvaluateService {
     public ResumeEvaluateResDto getDocumentResumes(EvaluationStatus status, FieldType type, String name, Pageable pageable) {
         Member currentMember = getCurrentMember();
         Page<ResumeResDto> resumeResDtos = resumeRepository.findMiddleEvaluation(currentMember, status, type, name, pageable);
+        String currentGeneration = applyInitialSetUpGetService.getCurrentGeneration();
 
         return ResumeEvaluateResDto.fromResume(
                 resumeRepository.countByState(ResumeState.SUBMITTED),
                 resumeRepository.findNotEvaluatedResume(currentMember),
                 resumeRepository.findEvaluatedResume(currentMember),
-                resumeResDtos);
+                resumeResDtos,
+                currentGeneration
+        );
     }
 
     @Transactional(readOnly = true)
@@ -74,12 +79,15 @@ public class ResumeEvaluateService {
         Member currentMember = getCurrentMember();
         Page<ResumeResDto> resumeResDtos =
                 resumeRepository.findFinalEvaluation(currentMember, status, type, name, pageable);
+        String currentGeneration = applyInitialSetUpGetService.getCurrentGeneration();
 
         return ResumeEvaluateResDto.fromResume(
                 resumeRepository.countByState(ResumeState.SUBMITTED),
                 resumeRepository.countByStateAndFinalDocumentEvaluationStatus(ResumeState.SUBMITTED, EvaluationStatus.NOTCHECKED),
                 resumeRepository.countByStateAndFinalDocumentEvaluationStatus(ResumeState.SUBMITTED, EvaluationStatus.PASS),
-                resumeResDtos);
+                resumeResDtos,
+                currentGeneration
+        );
     }
 
     @Transactional

--- a/src/main/java/com/tave/tavewebsite/global/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/tave/tavewebsite/global/redis/config/RedisCacheConfig.java
@@ -1,0 +1,33 @@
+package com.tave.tavewebsite.global.redis.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofDays(1));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+}


### PR DESCRIPTION
## ➕ 연관된 이슈
> #298
> Close #298

## 📑 작업 내용
> - 모집 기간 동안 고정된 Generation에 대해 잦은 조회 -> DB I/O 증가 -> 이를 캐싱으로 개선

캐싱 구현체는 Redis를 선택했습니다.
기존 Resume Data를 Redis에 캐싱하고 있었기 때문입니다. (이식성, 호환성)
LocalCache로 변경할 까 했지만, TTL 설정을 하기 위해 추가 코드를 작성해야하므로 Redis를 최종적으로 선택했습니다.

다음 네가지 API에 generation field를 추가했습니다.

- 대시보드 조회 (/v1/manager/dashboard)
- 서류 평가 (/v1/manager/resume/evaluate)
- 최종 서류 평가 (/v1/manager/resume/evaluate/final)
- 면접 현황(시간표) (/v1/manager/interview-final/time-table/(generation))

## ✂️ 스크린샷 (선택)
>

## 💭 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
